### PR TITLE
Fix unsigned long comparison error breaking Apple LLVM version 6.1.0

### DIFF
--- a/src/Index/src/DocTableDescriptor.cpp
+++ b/src/Index/src/DocTableDescriptor.cpp
@@ -120,7 +120,7 @@ namespace BitFunnel
           m_bytesPerItem(GetItemByteCount(schema))
     {
         // Make sure offset of the DocTable is properly aligned.
-        CHECK_EQ(bufferOffset % c_docTableByteAlignment, 0)
+        CHECK_EQ(bufferOffset % c_docTableByteAlignment, 0UL)
             << "incorrect buffer alignment.";
     }
 

--- a/src/Index/src/RowTableDescriptor.cpp
+++ b/src/Index/src/RowTableDescriptor.cpp
@@ -55,7 +55,7 @@ namespace BitFunnel
         //            "capacity not evenly rounded.");
 
         // // Make sure offset of this RowTable is properly aligned.
-        CHECK_EQ(rowTableBufferOffset % c_rowTableByteAlignment, 0)
+        CHECK_EQ(rowTableBufferOffset % c_rowTableByteAlignment, 0UL)
             << "incorrect buffer alignment.";
     }
 


### PR DESCRIPTION
Building fresh clone on OS X 10.10.2 and Apple LLVM 6.1.0 breaks when we
attempt to compare `unsigned long` with `int`. The fix for this issue is
to trivially use the `unsigned long` literal `0UL` instead of `0`. This
commit will introduce this fix where necessary.