### PR TITLE
Ignore -Wold-style-cast warnings for `MAP_FATAL`

### DIFF
--- a/src/Common/Utilities/src/AlignedBuffer.cpp
+++ b/src/Common/Utilities/src/AlignedBuffer.cpp
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
 #include <cstring>
 
 
@@ -63,7 +62,15 @@ namespace BitFunnel
                            MAP_ANON | MAP_PRIVATE,
                            -1,  // No file descriptor.
                            0);
+
+        // `MAP_FAILED` is implemented as an old-style cast on some old
+        // Unix-derived platforms. Note that issuing a `#pragma GCC` here is
+        // meant to cover both Clang and GCC, since the issue can manifest with
+        // either toolchain. See #233.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
         if (m_rawBuffer == MAP_FAILED)
+#pragma GCC diagnostic pop
         {
             std::stringstream errorMessage;
             errorMessage << "AlignedBuffer Failed to mmap: "

--- a/src/Common/Utilities/src/PackedArray.cpp
+++ b/src/Common/Utilities/src/PackedArray.cpp
@@ -149,9 +149,17 @@ namespace BitFunnel
                                                  MAP_ANON | MAP_PRIVATE,
                                                  -1,  // No file descriptor.
                                                  0));
+
+        // `MAP_FAILED` is implemented as an old-style cast on some old
+        // Unix-derived platforms. Note that issuing a `#pragma GCC` here is
+        // meant to cover both Clang and GCC, since the issue can manifest with
+        // either toolchain. See #233.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
             LogAssertB(buffer != MAP_FAILED,
                        "mmap failed %s",
                        std::strerror(errno));
+#pragma GCC diagnostic pop
 #endif
         }
         else

--- a/src/Common/Utilities/src/SimpleBuffer.cpp
+++ b/src/Common/Utilities/src/SimpleBuffer.cpp
@@ -59,7 +59,15 @@ namespace BitFunnel
                                                MAP_ANON | MAP_PRIVATE,
                                                -1,  // No file descriptor.
                                                0));
+
+            // `MAP_FAILED` is implemented as an old-style cast on some old
+            // Unix-derived platforms. Note that issuing a `#pragma GCC` here is
+            // meant to cover both Clang and GCC, since the issue can manifest
+            // with either toolchain. See #233.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
             if (m_buffer == MAP_FAILED)
+#pragma GCC diagnostic pop
             {
                 std::stringstream errorMessage;
                 errorMessage << "AlignedBuffer Failed to mmap: " <<


### PR DESCRIPTION
In #233 we describe a build break affecting users of the default
toolchains of various popular Unix derivatives (notably Ubuntu 16.04,
whose default g++ package is version 5.04, and OS X 10.10.2, whose
default Clang distribution is Apple LLVM 6.1.0, clang-602.0.53).

The build break concerns a symbol `MAP_FATAL`, which is implemented in
these versions of libc using an old C-style cast (typically
`(void*)-1`). Since the BitFunnel build system treats C-style casts as
compile errors, simply referencing this symbol breaks the build on these
platforms.

In this commit, we will suppress the `-Wold-style-cast` warnings on the
specific liens we're referencing `MAP_FATAL`. Since these lines occur
only on the Unix builds, the Windows codepath is unaffected. The
specific implementation of this warning suppression involves a `#pragma
GCC`, which both Clang and GCC respect, so this commit will work for
both OS X and for Ubuntu.
