### PR TITLE
Fix #225; work-around for build-breaking bug in some versions of GCC

### DIFF
--- a/inc/LoggerInterfaces/Check.h
+++ b/inc/LoggerInterfaces/Check.h
@@ -47,7 +47,16 @@ namespace Logging
                                            !std::is_pointer<T>::value &&
                                            !std::is_convertible<T, char const *>::value, T const &>::type value)
     {
+        // Work-around for what is believed to be a bug in g++ v5.4.0 (among
+        // other versions). See detailed discussion in #225.
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
         stream << value;
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic pop
+#endif
     }
 
     template <typename T>
@@ -56,7 +65,16 @@ namespace Logging
                             !std::is_convertible<T, char const *>::value) ||
                             std::is_null_pointer<T>::value, T const &>::type value)
     {
+        // Work-around for what is believed to be a bug in g++ v5.4.0 (among
+        // other versions). See detailed discussion in #225.
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
         if (value == nullptr)
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic pop
+#endif
         {
             stream << "(nullptr)";
         }

--- a/src/Plan/src/ByteCodeInterpreter.h
+++ b/src/Plan/src/ByteCodeInterpreter.h
@@ -257,7 +257,16 @@ namespace BitFunnel
 
     inline std::ostream& operator<<(std::ostream& out, const ByteCodeInterpreter::Opcode value)
     {
+        // Work-around for what is believed to be a bug in g++ v5.4.0 (among
+        // other versions). See detailed discussion in #225.
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
         out << c_opcodeNames[static_cast<size_t>(value)];
+#ifndef BITFUNNEL_PLATFORM_WINDOWS
+#pragma GCC diagnostic pop
+#endif
         return out;
     }
 


### PR DESCRIPTION
In #225 we investigate and discuss in detail a build break that affects
some versions of GCC (5.4.0 and 5.4.1, to name a few). In brief, these
versions of GCC emit a warning that claims some variables might be
uninitialized, though the warnings seem to be spurious.

After some discussion we concluded that it is likely a bug with the `<<`
operator, tracked in GCC as bug #66977. Since this toolchain is the
default distribution of the `g++` package in apt for Ubuntu 16.04, so it
is of interest for us to work-around this bug.

This commit, therefore, suppresses this specific warning for the
specific lines that cause it.
