### PR TITLE
doozer: Include LastTest.log as an artifact

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -28,5 +28,9 @@
         "ninja"
       ]
     },
-  }
+  },
+
+  "artifacts": [
+    "build-*/Testing/Temporary/LastTest.log"
+  ]
 }


### PR DESCRIPTION
This extracts the test logs as an artifact of its own so it's possible to see which test that failed.

Another option would be to just cat the file to stdout (so it would be part of the main buildlog)
