### PR TITLE
fixing missing cmath

### DIFF
--- a/src/Index/src/OptimalTermTreatments.cpp
+++ b/src/Index/src/OptimalTermTreatments.cpp
@@ -24,6 +24,7 @@
 #include <ostream>
 #include <stddef.h>
 #include <vector>
+#include <cmath>
 
 #include "BitFunnel/Term.h"
 


### PR DESCRIPTION
On OSX pow() needs <cmath>.