### PR TITLE
doozer: Add osx build

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -11,6 +11,8 @@
         "./Configure_Make.sh",
         "cd build-make",
         "make -j ${PARALLEL}",
+      ],
+      "testcmd": [
         "make test"
       ]
     },
@@ -26,6 +28,20 @@
         "cd build-ninja",
         "cmake -DCMAKE_BUILD_TYPE=RELEASE -G Ninja ..",
         "ninja"
+      ]
+    },
+    "osx": {
+      "buildenv": "osx",
+      "homebrew": {
+        "formulae": ["cmake"]
+      },
+      "buildcmd": [
+        "./Configure_Make.sh",
+        "cd build-make",
+        "make -j ${PARALLEL}",
+      ],
+      "testcmd": [
+        "make test"
       ]
     },
   },


### PR DESCRIPTION
Hi

This adds osx as a Doozer build target.

The build fails though (in NativeJit test), see https://doozer.io/andoma/BitFunnel/build/1

Btw, If you don't have an Mac at hand you can use Doozer "Push-To-Build" feature to get faster turnaround when testing.

Docs here https://doozer.io/docs/pushtobuild, but it builds down to this:

`git remote add doozer https://doozer.io/danluu/BitFunnel`

And to build for osx only (without even having to commit):

`git push doozer $(git stash create):refs/build/osx`

You get build status/output directly on the git command console.

Remember that you must set a password on your Doozer account for this to work.
