### PR TITLE
Calculate fixed-size block based on termtable having the most rows

### DIFF
--- a/Configure_MSVC.bat
+++ b/Configure_MSVC.bat
@@ -24,5 +24,5 @@ setlocal
 
 mkdir build-msvc
 pushd build-msvc
-cmake -G "Visual Studio 14 2015 Win64" ..
+cmake -G "Visual Studio 15 2017 Win64" ..
 popd

--- a/NativeJIT/appveyor.yml
+++ b/NativeJIT/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
     - staging_master
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 clone_depth: 1
 

--- a/NativeJIT/googletest/appveyor.yml
+++ b/NativeJIT/googletest/appveyor.yml
@@ -1,9 +1,10 @@
 version: '{build}'
 
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 environment:
   matrix:
+  - Toolset: v150
   - Toolset: v140
   - Toolset: v120
   - Toolset: v110
@@ -30,6 +31,7 @@ before_build:
     Write-Output "Platform: $env:PLATFORM"
     $generator = switch ($env:TOOLSET)
     {
+        "v150" {"Visual Studio 15 2017"}
         "v140" {"Visual Studio 14 2015"}
         "v120" {"Visual Studio 12 2013"}
         "v110" {"Visual Studio 11 2012"}

--- a/README.md
+++ b/README.md
@@ -70,23 +70,24 @@ If you use XCode, you'll have to either re-run `Configure_XCode` or run the `ZER
 
 ### Windows
 
-Install the following tools:
+You will need these tools:
 
-- Visual Studio 2015 with C++ compiler
 - CMake ([http://www.cmake.org/download/](http://www.cmake.org/download/))
+- Visual Studio 2017 with C++ compiler ([the free version](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx))
 
-You can get [the free version of Visual Studio here](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx).
-Note that if you're installing Visual Studio for the first time and select the
+**Note**: If you install Visual Studio for the first time and select the
 default install options, you won't get a C++ compiler. To force the install of
 the C++ compiler, you need to either create a new C++ project or open an
 existing C++ project.
 
-In order to configure solution for Visual Studio 2015 run the following
-commands from the root `BitFunnel` directory:
+Clone the BitFunnel repository and then run the following command in BitFunnel's root folder:
 
 ~~~
 .\Configure_MSVC.bat
 ~~~
 
-From now on you can use the generated solution `build-msvc\BitFunnel.sln` from Visual Studio
-or build from command line using `cmake`.
+**Note**: You will need to modify the CMake -G option if you use a different version of Visual Studio.
+Bitfunnel must be built as a 64-bit program, so 'Win64' must be part of the specified G option text.
+
+At this point, you can open the generated solution `BitFunnel_CMake.sln` from Visual Studio and then build it.
+Alternatively, you can build from the command line using `cmake --build build-MSVC`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
     - staging_master
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 clone_depth: 1
 

--- a/googletest/appveyor.yml
+++ b/googletest/appveyor.yml
@@ -1,9 +1,10 @@
 version: '{build}'
 
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 environment:
   matrix:
+  - Toolset: v150
   - Toolset: v140
   - Toolset: v120
   - Toolset: v110
@@ -30,6 +31,7 @@ before_build:
     Write-Output "Platform: $env:PLATFORM"
     $generator = switch ($env:TOOLSET)
     {
+        "v150" {"Visual Studio 15 2017"}
         "v140" {"Visual Studio 14 2015"}
         "v120" {"Visual Studio 12 2013"}
         "v110" {"Visual Studio 11 2012"}


### PR DESCRIPTION
This fix addresses https://github.com/BitFunnel/BitFunnel/issues/402, calculating the fixed-size block according to the needs of the most demanding termtable (i.e., the termtable that requires the most number of rows across all supported ranks).