### PR TITLE
Add -writer AddShardId option to bitfunnel filter

### DIFF
--- a/inc/BitFunnel/Chunks/Factories.h
+++ b/inc/BitFunnel/Chunks/Factories.h
@@ -33,6 +33,7 @@
 namespace BitFunnel
 {
     class IChunkManifestIngestor;
+    class IChunkWriter;
     class IConfiguration;
     class IDocument;
     class IDocumentFilter;
@@ -53,13 +54,15 @@ namespace BitFunnel
         std::unique_ptr<IChunkManifestIngestor>
             CreateChunkManifestIngestor(
                 IFileSystem& fileSystem,
-                IFileManager * fileManager,
+                IChunkWriter * writer,
                 std::vector<std::string> const & filePaths,
                 IConfiguration const & config,
                 IIngestor& ingestor,
                 IDocumentFilter & filter,
                 bool cacheDocuments);
 
+        std::unique_ptr<IChunkWriter>
+            CreateChunkWriter(IFileManager * fileManager);
 
         std::unique_ptr<IDocument>
             CreateDocument(IConfiguration const & configuration, DocId id);

--- a/inc/BitFunnel/Chunks/IChunkProcessor.h
+++ b/inc/BitFunnel/Chunks/IChunkProcessor.h
@@ -48,12 +48,15 @@ namespace BitFunnel
     class IChunkWriter : public IInterface
     {
     public:
-        // Writes the most recently read document to a stream.
-        virtual void Write(std::ostream& output) = 0;
+        // Set the chunk's index - this creates a stream used to output the current chunk
+        virtual void SetChunk(size_t index) = 0;
 
-        // Call this method once after a sequence of calls to Write() in
+        // Writes the document's bytes (in range m_start, m_end) to the current chunk's stream.
+        virtual void WriteDoc(BitFunnel::IDocument & document, char const * start, size_t size) = 0;
+
+        // Call this method once after a sequence of calls to WriteDoc() in
         // order to write any necessary epilogue and close the stream.
-        virtual void Complete(std::ostream& output) = 0;
+        virtual void Complete() = 0;
     };
 
 
@@ -97,8 +100,8 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) = 0;
         virtual void OnTerm(char const * term) = 0;
         virtual void OnStreamExit() = 0;
-        virtual void OnDocumentExit(IChunkWriter & writer,
+        virtual void OnDocumentExit(char const * start,
                                     size_t bytesRead) = 0;
-        virtual void OnFileExit(IChunkWriter & writer) = 0;
+        virtual void OnFileExit() = 0;
     };
 }

--- a/inc/BitFunnel/Index/IIngestor.h
+++ b/inc/BitFunnel/Index/IIngestor.h
@@ -29,6 +29,7 @@
 #include "BitFunnel/IInterface.h"           // inherits from IInterface.
 #include "BitFunnel/Index/IFactSet.h"       // FactHandle parameter.
 #include "BitFunnel/Index/DocumentHandle.h" // DocHandle return value.
+#include "BitFunnel/Configuration/IShardDefinition.h"
 
 
 namespace BitFunnel
@@ -142,6 +143,9 @@ namespace BitFunnel
         // Returns a number of Shards and a Shard with the given ShardId.
         virtual size_t GetShardCount() const = 0;
         virtual IShard& GetShard(size_t shard) const = 0;
+
+        // Return the shard definitions info
+        const virtual IShardDefinition& GetShardDef() const = 0;
 
         virtual IRecycler& GetRecycler() const = 0;
 

--- a/src/Chunks/src/CMakeLists.txt
+++ b/src/Chunks/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CPPFILES
     ChunkIngestor.cpp
     ChunkManifestIngestor.cpp
     ChunkReader.cpp
+    ChunkWriter.cpp
     Document.cpp
     DocumentFilters.cpp
     IngestChunks.cpp
@@ -23,6 +24,7 @@ set(PRIVATE_HFILES
     ChunkIngestor.h
     ChunkManifestIngestor.h
     ChunkReader.h
+    ChunkWriter.h
     Document.h
 )
 

--- a/src/Chunks/src/ChunkIngestor.cpp
+++ b/src/Chunks/src/ChunkIngestor.cpp
@@ -85,17 +85,20 @@ namespace BitFunnel
 
         if (m_filter.KeepDocument(*m_currentDocument))
         {
+            // Either we write out the document ...
             if (m_writer != nullptr)
             {
                 m_writer->WriteDoc(*m_currentDocument, start, bytesRead);
             }
-
-            m_ingestor.Add(m_currentDocument->GetDocId(), *m_currentDocument);
-            if (m_cacheDocuments)
-            {
-                DocId id = m_currentDocument->GetDocId();
-                m_ingestor.GetDocumentCache().Add(std::move(m_currentDocument),
-                                                  id);
+            // ... or else we ingest it
+            else {
+                m_ingestor.Add(m_currentDocument->GetDocId(), *m_currentDocument);
+                if (m_cacheDocuments)
+                {
+                    DocId id = m_currentDocument->GetDocId();
+                    m_ingestor.GetDocumentCache().Add(std::move(m_currentDocument),
+                        id);
+                }
             }
         }
 

--- a/src/Chunks/src/ChunkIngestor.h
+++ b/src/Chunks/src/ChunkIngestor.h
@@ -29,6 +29,7 @@
 #include "BitFunnel/Chunks/IChunkProcessor.h"   // Base class.
 #include "BitFunnel/NonCopyable.h"      // Base class.
 #include "Document.h"                   // std::unique_ptr<Document>.
+#include "ChunkWriter.h"
 
 
 namespace BitFunnel
@@ -44,7 +45,7 @@ namespace BitFunnel
                       IIngestor& ingestor,
                       bool cacheDocuments,
                       IDocumentFilter & filter,
-                      std::unique_ptr<std::ostream> output);
+                      IChunkWriter * writer);
 
         //
         // IChunkProcessor methods.
@@ -54,9 +55,9 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) override;
         virtual void OnTerm(char const * term) override;
         virtual void OnStreamExit() override;
-        virtual void OnDocumentExit(IChunkWriter & writer,
+        virtual void OnDocumentExit(char const * start,
                                     size_t bytesRead) override;
-        virtual void OnFileExit(IChunkWriter & writer) override;
+        virtual void OnFileExit() override;
 
     private:
         //
@@ -66,7 +67,7 @@ namespace BitFunnel
         IIngestor& m_ingestor;
         bool m_cacheDocuments;
         IDocumentFilter & m_filter;         // TODO: What about multi-threaded access?
-        std::unique_ptr<std::ostream> m_output;
+        IChunkWriter * m_writer;
 
         //
         // Other members

--- a/src/Chunks/src/ChunkManifestIngestor.h
+++ b/src/Chunks/src/ChunkManifestIngestor.h
@@ -40,7 +40,7 @@ namespace BitFunnel
     {
     public:
         ChunkManifestIngestor(IFileSystem & fileSystem,
-                              IFileManager * fileManager,
+                              IChunkWriter * writer,
                               std::vector<std::string> const & filePaths,
                               IConfiguration const & config,
                               IIngestor & ingestor,
@@ -62,7 +62,7 @@ namespace BitFunnel
         //
 
         IFileSystem & m_fileSystem;
-        IFileManager * m_fileManager;
+        IChunkWriter * m_writer;
         std::vector<std::string> const & m_filePaths;
         IConfiguration const & m_configuration;
         IIngestor& m_ingestor;

--- a/src/Chunks/src/ChunkReader.cpp
+++ b/src/Chunks/src/ChunkReader.cpp
@@ -25,7 +25,6 @@
 #include "BitFunnel/Chunks/IChunkProcessor.h"
 #include "BitFunnel/Exceptions.h"
 #include "ChunkReader.h"
-#include "ChunkWriter.h"
 
 
 namespace BitFunnel
@@ -60,9 +59,7 @@ namespace BitFunnel
 
         Consume(0);
 
-        // TODO: Is is bad to pass nullptr?
-        ChunkWriter writer(nullptr, nullptr);
-        m_processor.OnFileExit(writer);
+        m_processor.OnFileExit();
     }
 
 
@@ -83,9 +80,7 @@ namespace BitFunnel
             throw FatalError("length underflow.");
         }
 
-        ChunkWriter writer(start, m_next);
-
-        m_processor.OnDocumentExit(writer,
+        m_processor.OnDocumentExit(start,
                                    static_cast<size_t>(m_next - start));
     }
 

--- a/src/Chunks/src/ChunkReader.cpp
+++ b/src/Chunks/src/ChunkReader.cpp
@@ -25,6 +25,7 @@
 #include "BitFunnel/Chunks/IChunkProcessor.h"
 #include "BitFunnel/Exceptions.h"
 #include "ChunkReader.h"
+#include "ChunkWriter.h"
 
 
 namespace BitFunnel
@@ -199,30 +200,5 @@ namespace BitFunnel
         }
 
         GetChar();
-    }
-
-
-    //*************************************************************************
-    //
-    // ChunkReader::ChunkWriter
-    //
-    //*************************************************************************
-    ChunkReader::ChunkWriter::ChunkWriter(char const * start,
-                                          char const * end)
-      : m_start(start),
-        m_end(end)
-    {
-    }
-
-
-    void ChunkReader::ChunkWriter::Write(std::ostream & output)
-    {
-        output.write(m_start, m_end - m_start);
-    }
-
-
-    void ChunkReader::ChunkWriter::Complete(std::ostream & output)
-    {
-        output << '\0';
     }
 }

--- a/src/Chunks/src/ChunkWriter.cpp
+++ b/src/Chunks/src/ChunkWriter.cpp
@@ -22,6 +22,7 @@
 
 #include <sstream>
 
+#include "BitFunnel/Chunks/Factories.h"
 #include "ChunkWriter.h"
 
 
@@ -32,22 +33,31 @@ namespace BitFunnel
     // ChunkWriter
     //
     //*************************************************************************
-    ChunkWriter::ChunkWriter(char const * start,
-                                          char const * end)
-      : m_start(start),
-        m_end(end)
+
+    std::unique_ptr<IChunkWriter>
+        Factories::CreateChunkWriter(IFileManager * fileManager)
     {
+        return std::unique_ptr<IChunkWriter>(
+            new ChunkWriter(fileManager));
+    }
+
+    ChunkWriter::ChunkWriter(IFileManager * fileManager)
+      : m_fileManager(fileManager)    {
+    }
+
+    void ChunkWriter::SetChunk(size_t index)
+    {
+        m_output = m_fileManager->Chunk(index).OpenForWrite();
+    }
+
+    void ChunkWriter::WriteDoc(BitFunnel::IDocument & /*document*/, char const * start, size_t size)
+    {
+        m_output->write(start, size);
     }
 
 
-    void ChunkWriter::Write(std::ostream & output)
+    void ChunkWriter::Complete()
     {
-        output.write(m_start, m_end - m_start);
-    }
-
-
-    void ChunkWriter::Complete(std::ostream & output)
-    {
-        output << '\0';
+        *m_output << '\0';
     }
 }

--- a/src/Chunks/src/ChunkWriter.cpp
+++ b/src/Chunks/src/ChunkWriter.cpp
@@ -20,55 +20,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#pragma once
+#include <sstream>
 
-#include <stdint.h>
-#include <vector>
-
-#include "BitFunnel/NonCopyable.h"  // Base class.
-#include "BitFunnel/Term.h"         // Term::StreamId return value.
+#include "ChunkWriter.h"
 
 
 namespace BitFunnel
 {
-    class IChunkProcessor;
-
     //*************************************************************************
     //
-    // ChunkReader
-    //
-    // Parses a buffer of documents encoded in the BitFunnel chunk format,
-    // generating callbacks to an IChunkProcessor.
+    // ChunkWriter
     //
     //*************************************************************************
-    class ChunkReader : public NonCopyable
+    ChunkWriter::ChunkWriter(char const * start,
+                                          char const * end)
+      : m_start(start),
+        m_end(end)
     {
-    // DESIGN NOTE: Need to add arena allocators.
-    public:
-        ChunkReader(char const * start,
-                    char const * end,
-                    IChunkProcessor& processor);
+    }
 
-    private:
-        void ProcessDocument();
-        void ProcessStream();
-        char const * GetToken();
 
-        DocId GetDocId();
-        Term::StreamId GetStreamId();
+    void ChunkWriter::Write(std::ostream & output)
+    {
+        output.write(m_start, m_end - m_start);
+    }
 
-        uint64_t GetHexValue(uint64_t digitCount);
-        void Consume(char c);
-        char GetChar();
-        char PeekChar();
 
-        // Construtor parameters.
-        IChunkProcessor& m_processor;
-
-        // Next character to be processed.
-        char const * m_next;
-
-        // Pointer to character beyond the end of m_input.
-        char const * m_end;
-    };
+    void ChunkWriter::Complete(std::ostream & output)
+    {
+        output << '\0';
+    }
 }

--- a/src/Chunks/src/ChunkWriter.h
+++ b/src/Chunks/src/ChunkWriter.h
@@ -25,50 +25,38 @@
 #include <stdint.h>
 #include <vector>
 
-#include "BitFunnel/NonCopyable.h"  // Base class.
-#include "BitFunnel/Term.h"         // Term::StreamId return value.
+#include "BitFunnel/Chunks/IChunkProcessor.h"
 
 
 namespace BitFunnel
 {
-    class IChunkProcessor;
 
     //*************************************************************************
     //
-    // ChunkReader
+    // ChunkWriter
     //
-    // Parses a buffer of documents encoded in the BitFunnel chunk format,
-    // generating callbacks to an IChunkProcessor.
+    // Outputs a buffer of documents encoded in the BitFunnel chunk format
+    // to an output stream
     //
     //*************************************************************************
-    class ChunkReader : public NonCopyable
+    class ChunkWriter : public IChunkWriter
     {
-    // DESIGN NOTE: Need to add arena allocators.
     public:
-        ChunkReader(char const * start,
-                    char const * end,
-                    IChunkProcessor& processor);
+        ChunkWriter(char const * start,
+            char const * end);
+
+        // Writes the bytes in range [m_start, m_end) to the specified
+        // stream. ChunkReader uses this method to write the range of bytes
+        // corresponding to a single document.
+        void Write(std::ostream & output) override;
+
+        // Writes a single '\0' to the specified stream. ChunkReader uses
+        // this method to write the closing `\0` after a sequence of
+        // documents.
+        void Complete(std::ostream & output) override;
 
     private:
-        void ProcessDocument();
-        void ProcessStream();
-        char const * GetToken();
-
-        DocId GetDocId();
-        Term::StreamId GetStreamId();
-
-        uint64_t GetHexValue(uint64_t digitCount);
-        void Consume(char c);
-        char GetChar();
-        char PeekChar();
-
-        // Construtor parameters.
-        IChunkProcessor& m_processor;
-
-        // Next character to be processed.
-        char const * m_next;
-
-        // Pointer to character beyond the end of m_input.
+        char const * m_start;
         char const * m_end;
     };
 }

--- a/src/Chunks/src/ChunkWriter.h
+++ b/src/Chunks/src/ChunkWriter.h
@@ -26,6 +26,8 @@
 #include <vector>
 
 #include "BitFunnel/Chunks/IChunkProcessor.h"
+#include "BitFunnel/IFileManager.h"
+#include "BitFunnel/NonCopyable.h"
 
 
 namespace BitFunnel
@@ -39,24 +41,23 @@ namespace BitFunnel
     // to an output stream
     //
     //*************************************************************************
-    class ChunkWriter : public IChunkWriter
+    class ChunkWriter : public NonCopyable, public IChunkWriter
     {
     public:
-        ChunkWriter(char const * start,
-            char const * end);
+        ChunkWriter(IFileManager * fileManager);
 
-        // Writes the bytes in range [m_start, m_end) to the specified
-        // stream. ChunkReader uses this method to write the range of bytes
-        // corresponding to a single document.
-        void Write(std::ostream & output) override;
+        // Sets the index of the chunk to be processed.
+        // This creates the stream from the fileManager used to output the current chunk
+        void SetChunk(size_t index) override;
 
-        // Writes a single '\0' to the specified stream. ChunkReader uses
-        // this method to write the closing `\0` after a sequence of
-        // documents.
-        void Complete(std::ostream & output) override;
+        // Writes the document's bytes (in range m_start, m_end) to the current chunk's stream.
+        void WriteDoc(BitFunnel::IDocument & document, char const * start, size_t size) override;
+
+        // Writes a single '\0' to the specified stream, completing the outputted chunk.
+        void Complete() override;
 
     private:
-        char const * m_start;
-        char const * m_end;
+        IFileManager * m_fileManager;
+        std::unique_ptr<std::ostream> m_output;
     };
 }

--- a/src/Chunks/test/ChunkEventTracer.h
+++ b/src/Chunks/test/ChunkEventTracer.h
@@ -94,14 +94,14 @@ namespace BitFunnel
             }
 
 
-            void OnDocumentExit(IChunkWriter & /*writer*/,
-                                size_t /*sourceByteSize*/) override
+            void OnDocumentExit(char const * /* start */,
+                                size_t /* bytesRead */) override
             {
                 m_trace << "OnDocumentExit" << std::endl;
             }
 
 
-            void OnFileExit(IChunkWriter & /*writer*/) override
+            void OnFileExit() override
             {
                 m_trace << "OnFileExit" << std::endl;
             }

--- a/src/Index/src/Ingestor.cpp
+++ b/src/Index/src/Ingestor.cpp
@@ -254,6 +254,12 @@ namespace BitFunnel
     }
 
 
+    const IShardDefinition & Ingestor::GetShardDef() const
+    {
+        return m_shardDefinition;
+    }
+
+
     ITokenManager& Ingestor::GetTokenManager() const
     {
         return *m_tokenManager;

--- a/src/Index/src/Ingestor.h
+++ b/src/Index/src/Ingestor.h
@@ -133,6 +133,9 @@ namespace BitFunnel
         virtual size_t GetShardCount() const override;
         virtual IShard& GetShard(size_t shard) const override;
 
+        // Return the Shard used for a given postcount
+        const virtual IShardDefinition & GetShardDef() const override;
+
         virtual IRecycler& GetRecycler() const override;
 
         virtual ITokenManager& GetTokenManager() const override;

--- a/tools/BitFunnel/src/AddShardTermWriter.cpp
+++ b/tools/BitFunnel/src/AddShardTermWriter.cpp
@@ -1,0 +1,71 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <sstream>
+
+#include "AddShardTermWriter.h"
+#include "BitFunnel/Index/IDocument.h"
+#include "BitFunnel/Configuration/IShardDefinition.h"
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // AddShardTermWriter
+    //
+    //*************************************************************************
+
+    AddShardTermWriter::AddShardTermWriter(IFileManager * fileManager, IIngestor & ingestor)
+      : m_fileManager(fileManager),
+        m_ingestor(ingestor)
+    {
+    }
+
+    void AddShardTermWriter::SetChunk(size_t index)
+    {
+        m_output = m_fileManager->Chunk(index).OpenForWrite();
+    }
+
+    void AddShardTermWriter::WriteDoc(BitFunnel::IDocument & document, char const * start, size_t size)
+    {
+        // We need min/max count info about the shard the document's posting count belongs in
+        // (Note: We add one to the posting count to account for the added shard term)
+        const BitFunnel::IShardDefinition & sharddef = m_ingestor.GetShardDef();
+        auto shardid = sharddef.GetShard(document.GetPostingCount()+1);
+        auto mincnt = sharddef.GetMinPostingCount(shardid);
+        auto maxcnt = sharddef.GetMaxPostingCount(shardid);
+        std::ostringstream shardterm;
+
+        // Write out all of document except last document-ending byte
+        m_output->write(start, size-1);
+
+        // Write out shard term into stream 00 (default for body)
+        *m_output << "00" << '\0' << "SHARD_" << mincnt << "_" << maxcnt << '\0' << '\0' << '\0';
+    }
+
+
+    void AddShardTermWriter::Complete()
+    {
+        *m_output << '\0';
+    }
+}

--- a/tools/BitFunnel/src/AddShardTermWriter.h
+++ b/tools/BitFunnel/src/AddShardTermWriter.h
@@ -20,51 +20,47 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#pragma once
 
-#include "BitFunnel/IExecutable.h"  // Base class.
+#include <stdint.h>
+#include <vector>
+
+#include "BitFunnel/Chunks/IChunkProcessor.h"
+#include "BitFunnel/Index/IIngestor.h"
+#include "BitFunnel/IFileManager.h"
+#include "BitFunnel/NonCopyable.h"
 
 
 namespace BitFunnel
 {
-    class IDocumentFilter;
-    class IFileSystem;
-
-    enum class WriterIds {
-        ChunkWriter,
-        AddShardIdWriter
-    };
 
     //*************************************************************************
     //
-    // FilterChunks
+    // AddShardTermWriter
     //
-    // An IExecutable that copies a set of chunk files specified by a manifest,
-    // while filtering the documents based on a set of predicates, including
-    // random sampling, posting count in range, and total number of documents.
+    // Outputs a buffer of documents encoded in the BitFunnel chunk format
+    // to an output stream. Importantly, it also injects into each document
+    // a searchable term that identifies the shard the document belongs to.
     //
     //*************************************************************************
-    class FilterChunks : public IExecutable
+    class AddShardTermWriter : public NonCopyable, public IChunkWriter
     {
     public:
-        FilterChunks(IFileSystem & fileSystem);
+        AddShardTermWriter(IFileManager * fileManager, IIngestor & ingestor);
 
-        //
-        // IExecutable methods
-        //
-        virtual int Main(std::istream& input,
-                         std::ostream& output,
-                         int argc,
-                         char const *argv[]) override;
+        // Sets the index of the chunk to be processed.
+        // This creates the stream from the fileManager used to output the current chunk
+        void SetChunk(size_t index) override;
+
+        // Writes the document's bytes (in range m_start, m_end) to the current chunk's stream.
+        void WriteDoc(BitFunnel::IDocument & document, char const * start, size_t size) override;
+
+        // Writes a single '\0' to the specified stream, completing the outputted chunk.
+        void Complete() override;
 
     private:
-        void FilterChunkList(
-            std::ostream& output,
-            char const * intermediateDirectory,
-            char const * chunkListFileName,
-            int gramSize,
-            IDocumentFilter & filter,
-            WriterIds writer) const;
-
-        IFileSystem& m_fileSystem;
+        IFileManager * m_fileManager;
+        IIngestor & m_ingestor;
+        std::unique_ptr<std::ostream> m_output;
     };
 }

--- a/tools/BitFunnel/src/CMakeLists.txt
+++ b/tools/BitFunnel/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # BitFunnel/tools/BitFunnel/src
 
 set(CPPFILES
+    AddShardTermWriter.cpp
     AnalyzeCommand.cpp
     BitFunnelTool.cpp
     CacheLineCountCommand.cpp
@@ -38,6 +39,7 @@ set(POSIX_CPPFILES
 )
 
 set(PRIVATE_HFILES
+    AddShardTermWriter.h
     AnalyzeCommand.h
     BitFunnelTool.h
     CacheLineCountCommand.h

--- a/tools/BitFunnel/src/FilterChunks.cpp
+++ b/tools/BitFunnel/src/FilterChunks.cpp
@@ -210,9 +210,11 @@ namespace BitFunnel
             outputDirectory,
             index->GetFileSystem());
 
+        auto writer = Factories::CreateChunkWriter(fileManager.get());
+
         auto manifest = Factories::CreateChunkManifestIngestor(
             m_fileSystem,
-            fileManager.get(),
+            writer.get(),
             filePaths,
             configuration,
             ingestor,


### PR DESCRIPTION
With this change, use of the `-writer AddShardId` option will output chunks which have an extra shard term injected into every document. It appends an extra '00' stream that holds a single term that identifies the shard (e.g., `SHARD_2048_4096`).

This change also avoids index building (ingestion) whenever a writer is used (which `filter` always does but `repl` does not).