### PR TITLE
Add -writer option to bitfunnel filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(CHUNKS_HFILES
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Chunks/DocumentFilters.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Chunks/IChunkManifestIngestor.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Chunks/IChunkProcessor.h
+  ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Chunks/IChunkWriter.h
 )
 
 set(DATA_HFILES

--- a/inc/BitFunnel/Chunks/Factories.h
+++ b/inc/BitFunnel/Chunks/Factories.h
@@ -57,7 +57,6 @@ namespace BitFunnel
             CreateChunkManifestIngestor(
                 IFileSystem& fileSystem,
                 IChunkWriterFactory* chunkWriterFactory,
-//                IFileManager * fileManager,
                 std::vector<std::string> const & filePaths,
                 IConfiguration const & config,
                 IIngestor& ingestor,

--- a/inc/BitFunnel/Chunks/Factories.h
+++ b/inc/BitFunnel/Chunks/Factories.h
@@ -33,12 +33,15 @@
 namespace BitFunnel
 {
     class IChunkManifestIngestor;
+    class IChunkWriterFactory;
     class IConfiguration;
     class IDocument;
     class IDocumentFilter;
     class IFileManager;
     class IFileSystem;
     class IIngestor;
+    class IShardDefinition;
+
 
     namespace Factories
     {
@@ -53,13 +56,23 @@ namespace BitFunnel
         std::unique_ptr<IChunkManifestIngestor>
             CreateChunkManifestIngestor(
                 IFileSystem& fileSystem,
-                IFileManager * fileManager,
+                IChunkWriterFactory* chunkWriterFactory,
+//                IFileManager * fileManager,
                 std::vector<std::string> const & filePaths,
                 IConfiguration const & config,
                 IIngestor& ingestor,
                 IDocumentFilter & filter,
                 bool cacheDocuments);
 
+
+        std::unique_ptr<IChunkWriterFactory>
+            CreateAnnotatingChunkWriterFactory(
+                IFileManager& fileManager,
+                IShardDefinition const & shardDefinition);
+
+        std::unique_ptr<IChunkWriterFactory>
+            CreateCopyingChunkWriterFactory(
+                IFileManager& fileManager);
 
         std::unique_ptr<IDocument>
             CreateDocument(IConfiguration const & configuration, DocId id);

--- a/inc/BitFunnel/Chunks/IChunkProcessor.h
+++ b/inc/BitFunnel/Chunks/IChunkProcessor.h
@@ -77,11 +77,7 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) = 0;
         virtual void OnTerm(char const * term) = 0;
         virtual void OnStreamExit() = 0;
-        virtual void OnDocumentExit(char const * start,
-                                    size_t bytesRead) = 0;
-        //virtual void OnDocumentExit(IChunkWriter & writer,
-        //                            size_t bytesRead) = 0;
+        virtual void OnDocumentExit(char const * start, size_t length) = 0;
         virtual void OnFileExit() = 0;
-//        virtual void OnFileExit(IChunkWriter & writer) = 0;
     };
 }

--- a/inc/BitFunnel/Chunks/IChunkProcessor.h
+++ b/inc/BitFunnel/Chunks/IChunkProcessor.h
@@ -33,28 +33,8 @@
 
 namespace BitFunnel
 {
+    class IChunkWriter;
     class IDocument;
-
-    //*************************************************************************
-    //
-    // IChunkWriter
-    //
-    // Interfaces passed to IChunkProcessor to aid in copying a subset of
-    // documents from a chunk file. IChunkWriter provides methods for writing
-    // documents in the format of the reader that generates IChunkProcessor
-    // callbacks.
-    //
-    //*************************************************************************
-    class IChunkWriter : public IInterface
-    {
-    public:
-        // Writes the most recently read document to a stream.
-        virtual void Write(std::ostream& output) = 0;
-
-        // Call this method once after a sequence of calls to Write() in
-        // order to write any necessary epilogue and close the stream.
-        virtual void Complete(std::ostream& output) = 0;
-    };
 
 
     //*************************************************************************

--- a/inc/BitFunnel/Chunks/IChunkProcessor.h
+++ b/inc/BitFunnel/Chunks/IChunkProcessor.h
@@ -77,8 +77,11 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) = 0;
         virtual void OnTerm(char const * term) = 0;
         virtual void OnStreamExit() = 0;
-        virtual void OnDocumentExit(IChunkWriter & writer,
+        virtual void OnDocumentExit(char const * start,
                                     size_t bytesRead) = 0;
-        virtual void OnFileExit(IChunkWriter & writer) = 0;
+        //virtual void OnDocumentExit(IChunkWriter & writer,
+        //                            size_t bytesRead) = 0;
+        virtual void OnFileExit() = 0;
+//        virtual void OnFileExit(IChunkWriter & writer) = 0;
     };
 }

--- a/inc/BitFunnel/Chunks/IChunkWriter.h
+++ b/inc/BitFunnel/Chunks/IChunkWriter.h
@@ -1,0 +1,52 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <iosfwd>                       // std::ostream& parameter.
+
+#include "BitFunnel/IInterface.h"       // Base class.
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // IChunkWriter
+    //
+    // Interfaces passed to IChunkProcessor to aid in copying a subset of
+    // documents from a chunk file. IChunkWriter provides methods for writing
+    // documents in the format of the reader that generates IChunkProcessor
+    // callbacks.
+    //
+    //*************************************************************************
+    class IChunkWriter : public IInterface
+    {
+    public:
+        // Writes the most recently read document to a stream.
+        virtual void Write(std::ostream& output) = 0;
+
+        // Call this method once after a sequence of calls to Write() in
+        // order to write any necessary epilogue and close the stream.
+        virtual void Complete(std::ostream& output) = 0;
+    };
+}

--- a/inc/BitFunnel/Chunks/IChunkWriter.h
+++ b/inc/BitFunnel/Chunks/IChunkWriter.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include <iosfwd>                   // std::ostream& parameter.
-
 #include "BitFunnel/IInterface.h"   // Base class.
 #include "BitFunnel/Noncopyable.h"  // Base class.
 
@@ -34,34 +32,32 @@ namespace BitFunnel
     //
     // IChunkWriter
     //
-    // Interfaces passed to IChunkProcessor to aid in copying a subset of
+    // Interface passed to IChunkProcessor to aid in copying a subset of
     // documents from a chunk file. IChunkWriter provides methods for writing
     // documents in the format of the reader that generates IChunkProcessor
     // callbacks.
     //
     //*************************************************************************
-
-    //class IChunkWriter : public IInterface
-    //{
-    //public:
-    //    // Writes the most recently read document to a stream.
-    //    virtual void Write(std::ostream& output) = 0;
-
-    //    // Call this method once after a sequence of calls to Write() in
-    //    // order to write any necessary epilogue and close the stream.
-    //    virtual void Complete(std::ostream& output) = 0;
-    //};
-
-
     class IChunkWriter : public IInterface, NonCopyable
     {
     public:
+        // Writes the document.
+        // The start and length parameters refer to a buffer containing the
+        // BitFunnel corpus/chunk file encoding of the document.
         virtual void Write(IDocument const & document,
-            char const * start,
-            size_t length) = 0;
+                           char const * start,
+                           size_t length) = 0;
     };
 
 
+    //*************************************************************************
+    //
+    // IChunkWriterFactory
+    //
+    // Interface that constructs IChunkWriters. Typically one IChunkWriter is
+    // constructed for each corpus/chunk file processed.
+    //
+    //*************************************************************************
     class IChunkWriterFactory : public IInterface, NonCopyable
     {
     public:

--- a/inc/BitFunnel/Chunks/IChunkWriter.h
+++ b/inc/BitFunnel/Chunks/IChunkWriter.h
@@ -22,9 +22,10 @@
 
 #pragma once
 
-#include <iosfwd>                       // std::ostream& parameter.
+#include <iosfwd>                   // std::ostream& parameter.
 
-#include "BitFunnel/IInterface.h"       // Base class.
+#include "BitFunnel/IInterface.h"   // Base class.
+#include "BitFunnel/Noncopyable.h"  // Base class.
 
 
 namespace BitFunnel
@@ -39,14 +40,32 @@ namespace BitFunnel
     // callbacks.
     //
     //*************************************************************************
-    class IChunkWriter : public IInterface
+
+    //class IChunkWriter : public IInterface
+    //{
+    //public:
+    //    // Writes the most recently read document to a stream.
+    //    virtual void Write(std::ostream& output) = 0;
+
+    //    // Call this method once after a sequence of calls to Write() in
+    //    // order to write any necessary epilogue and close the stream.
+    //    virtual void Complete(std::ostream& output) = 0;
+    //};
+
+
+    class IChunkWriter : public IInterface, NonCopyable
     {
     public:
-        // Writes the most recently read document to a stream.
-        virtual void Write(std::ostream& output) = 0;
+        virtual void Write(IDocument const & document,
+            char const * start,
+            size_t length) = 0;
+    };
 
-        // Call this method once after a sequence of calls to Write() in
-        // order to write any necessary epilogue and close the stream.
-        virtual void Complete(std::ostream& output) = 0;
+
+    class IChunkWriterFactory : public IInterface, NonCopyable
+    {
+    public:
+        virtual std::unique_ptr<IChunkWriter>
+            CreateChunkWriter(size_t index) = 0;
     };
 }

--- a/inc/BitFunnel/Chunks/IChunkWriter.h
+++ b/inc/BitFunnel/Chunks/IChunkWriter.h
@@ -43,7 +43,7 @@ namespace BitFunnel
     public:
         // Writes the document.
         // The start and length parameters refer to a buffer containing the
-        // BitFunnel corpus/chunk file encoding of the document.
+        // BitFunnel corpus/chunk file encoding of the document to be written.
         virtual void Write(IDocument const & document,
                            char const * start,
                            size_t length) = 0;

--- a/inc/BitFunnel/Index/IIngestor.h
+++ b/inc/BitFunnel/Index/IIngestor.h
@@ -53,8 +53,8 @@ namespace BitFunnel
 
     //*************************************************************************
     //
-    // IIngester is an abstract class or interface of classes that
-    // represents the entire BitFunnel index as viewed by the document ingestion
+    // IIngester is an abstract class or interface for classes that
+    // represent the entire BitFunnel index as viewed by the document ingestion
     // pipeline. This interface is used by the host of the index to populate the
     // index. Provides methods to add and remove documents, verify if a document
     // exists in the index, and assert facts on documents in the index.

--- a/inc/BitFunnel/Index/IIngestor.h
+++ b/inc/BitFunnel/Index/IIngestor.h
@@ -39,6 +39,7 @@ namespace BitFunnel
     class IRecycler;
     class ITokenManager;
     class IShard;
+    class IShardDefinition;
     class ITermToText;
 
     // BITFUNNELTYPES
@@ -142,6 +143,8 @@ namespace BitFunnel
         // Returns a number of Shards and a Shard with the given ShardId.
         virtual size_t GetShardCount() const = 0;
         virtual IShard& GetShard(size_t shard) const = 0;
+
+        virtual IShardDefinition const & GetShardDefinition() const = 0;
 
         virtual IRecycler& GetRecycler() const = 0;
 

--- a/src/Chunks/src/CMakeLists.txt
+++ b/src/Chunks/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CPPFILES
     ChunkIngestor.cpp
     ChunkManifestIngestor.cpp
     ChunkReader.cpp
+	ChunkWriters.cpp
     Document.cpp
     DocumentFilters.cpp
     IngestChunks.cpp
@@ -23,6 +24,7 @@ set(PRIVATE_HFILES
     ChunkIngestor.h
     ChunkManifestIngestor.h
     ChunkReader.h
+	ChunkWriters.h
     Document.h
 )
 

--- a/src/Chunks/src/ChunkIngestor.cpp
+++ b/src/Chunks/src/ChunkIngestor.cpp
@@ -23,6 +23,7 @@
 #include <iostream>     // TODO: remove
 
 #include "BitFunnel/Chunks/Factories.h"
+#include "BitFunnel/Chunks/IChunkWriter.h"
 #include "BitFunnel/Index/IDocumentCache.h"
 #include "BitFunnel/Index/IIngestor.h"
 #include "ChunkIngestor.h"

--- a/src/Chunks/src/ChunkIngestor.cpp
+++ b/src/Chunks/src/ChunkIngestor.cpp
@@ -41,13 +41,11 @@ namespace BitFunnel
                                  bool cacheDocuments,
                                  IDocumentFilter & filter,
                                  IChunkWriter * chunkWriter)
-                                 //std::unique_ptr<std::ostream> output)
       : m_config(config),
         m_ingestor(ingestor),
         m_cacheDocuments(cacheDocuments),
         m_filter(filter),
         m_chunkWriter(chunkWriter)
-//        m_output(std::move(output))
     {
     }
 
@@ -83,24 +81,19 @@ namespace BitFunnel
 
     void ChunkIngestor::OnDocumentExit(char const * start,
                                        size_t length)
-    //void ChunkIngestor::OnDocumentExit(IChunkWriter & writer,
-    //                                   size_t bytesRead)
     {
         m_currentDocument->CloseDocument(length);
 
         if (m_filter.KeepDocument(*m_currentDocument))
         {
-            //if (m_output.get() != nullptr)
-            //{
-            //    writer.Write(*m_output);
-            //}
-
             if (m_chunkWriter != nullptr)
             {
+                // If we have an IChunkWriter, write the current document.
                 m_chunkWriter->Write(*m_currentDocument, start, length);
             }
             else
             {
+                // Otherwise, ingest the current document.
                 m_ingestor.Add(m_currentDocument->GetDocId(), *m_currentDocument);
                 if (m_cacheDocuments)
                 {
@@ -115,12 +108,7 @@ namespace BitFunnel
     }
 
 
-//    void ChunkIngestor::OnFileExit(IChunkWriter & /*writer*/)
     void ChunkIngestor::OnFileExit()
     {
-        //if (m_output.get() != nullptr)
-        //{
-        //    writer.Complete(*m_output);
-        //}
     }
 }

--- a/src/Chunks/src/ChunkIngestor.h
+++ b/src/Chunks/src/ChunkIngestor.h
@@ -53,6 +53,8 @@ namespace BitFunnel
         virtual void OnTerm(char const * term) override;
         virtual void OnStreamExit() override;
         virtual void OnDocumentExit(char const * start, size_t length) override;
+
+        // TODO: Consider eliminating OnFileExit()? Also eliminate OnFileEnter()?
         virtual void OnFileExit() override;
 
     private:

--- a/src/Chunks/src/ChunkIngestor.h
+++ b/src/Chunks/src/ChunkIngestor.h
@@ -44,7 +44,8 @@ namespace BitFunnel
                       IIngestor& ingestor,
                       bool cacheDocuments,
                       IDocumentFilter & filter,
-                      std::unique_ptr<std::ostream> output);
+                      IChunkWriter * chunkWriter);
+//                      std::unique_ptr<std::ostream> output);
 
         //
         // IChunkProcessor methods.
@@ -54,9 +55,12 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) override;
         virtual void OnTerm(char const * term) override;
         virtual void OnStreamExit() override;
-        virtual void OnDocumentExit(IChunkWriter & writer,
+        virtual void OnDocumentExit(char const * start,
                                     size_t bytesRead) override;
-        virtual void OnFileExit(IChunkWriter & writer) override;
+        //virtual void OnDocumentExit(IChunkWriter & writer,
+        //                            size_t bytesRead) override;
+        virtual void OnFileExit() override;
+//        virtual void OnFileExit(IChunkWriter & writer) override;
 
     private:
         //
@@ -66,7 +70,8 @@ namespace BitFunnel
         IIngestor& m_ingestor;
         bool m_cacheDocuments;
         IDocumentFilter & m_filter;         // TODO: What about multi-threaded access?
-        std::unique_ptr<std::ostream> m_output;
+        IChunkWriter * m_chunkWriter;
+//        std::unique_ptr<std::ostream> m_output;
 
         //
         // Other members

--- a/src/Chunks/src/ChunkIngestor.h
+++ b/src/Chunks/src/ChunkIngestor.h
@@ -22,13 +22,11 @@
 
 #pragma once
 
-#include <iosfwd>                       // std::ostream template parameter.
 #include <memory>                       // std::unqiue_ptr member.
-#include <vector>                       // std::vector member.
 
 #include "BitFunnel/Chunks/IChunkProcessor.h"   // Base class.
-#include "BitFunnel/NonCopyable.h"      // Base class.
-#include "Document.h"                   // std::unique_ptr<Document>.
+#include "BitFunnel/NonCopyable.h"              // Base class.
+#include "Document.h"                           // std::unique_ptr<Document>.
 
 
 namespace BitFunnel
@@ -45,7 +43,6 @@ namespace BitFunnel
                       bool cacheDocuments,
                       IDocumentFilter & filter,
                       IChunkWriter * chunkWriter);
-//                      std::unique_ptr<std::ostream> output);
 
         //
         // IChunkProcessor methods.
@@ -55,12 +52,8 @@ namespace BitFunnel
         virtual void OnStreamEnter(Term::StreamId id) override;
         virtual void OnTerm(char const * term) override;
         virtual void OnStreamExit() override;
-        virtual void OnDocumentExit(char const * start,
-                                    size_t bytesRead) override;
-        //virtual void OnDocumentExit(IChunkWriter & writer,
-        //                            size_t bytesRead) override;
+        virtual void OnDocumentExit(char const * start, size_t length) override;
         virtual void OnFileExit() override;
-//        virtual void OnFileExit(IChunkWriter & writer) override;
 
     private:
         //
@@ -71,7 +64,6 @@ namespace BitFunnel
         bool m_cacheDocuments;
         IDocumentFilter & m_filter;         // TODO: What about multi-threaded access?
         IChunkWriter * m_chunkWriter;
-//        std::unique_ptr<std::ostream> m_output;
 
         //
         // Other members

--- a/src/Chunks/src/ChunkManifestIngestor.cpp
+++ b/src/Chunks/src/ChunkManifestIngestor.cpp
@@ -20,11 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <fstream>
-#include <iostream>
+#include <iostream>     // TODO: this library method should not print to std::cout.
+#include <istream>
 #include <sstream>
 
 #include "BitFunnel/Chunks/Factories.h"
+#include "BitFunnel/Chunks/IChunkWriter.h"
 #include "BitFunnel/Configuration/IFileSystem.h"
 #include "BitFunnel/Exceptions.h"
 #include "BitFunnel/IFileManager.h"
@@ -39,7 +40,6 @@ namespace BitFunnel
         Factories::CreateChunkManifestIngestor(
             IFileSystem& fileSystem,
             IChunkWriterFactory* chunkWriterFactory,
-//            IFileManager * fileManager,
             std::vector<std::string> const & filePaths,
             IConfiguration const & config,
             IIngestor& ingestor,
@@ -47,22 +47,19 @@ namespace BitFunnel
             bool cacheDocuments)
     {
         return std::unique_ptr<IChunkManifestIngestor>(
-            new ChunkManifestIngestor(
-                fileSystem,
-                chunkWriterFactory,
-//                fileManager,
-                filePaths,
-                config,
-                ingestor,
-                filter,
-                cacheDocuments));
+            new ChunkManifestIngestor(fileSystem,
+                                      chunkWriterFactory,
+                                      filePaths,
+                                      config,
+                                      ingestor,
+                                      filter,
+                                      cacheDocuments));
     }
 
 
     ChunkManifestIngestor::ChunkManifestIngestor(
         IFileSystem& fileSystem,
         IChunkWriterFactory* chunkWriterFactory,
-//        IFileManager * fileManager,
         std::vector<std::string> const & filePaths,
         IConfiguration const & config,
         IIngestor& ingestor,
@@ -70,7 +67,6 @@ namespace BitFunnel
         bool cacheDocuments)
       : m_fileSystem(fileSystem),
         m_chunkWriterFactory(chunkWriterFactory),
-//        m_fileManager(fileManager),
         m_filePaths(filePaths),
         m_configuration(config),
         m_ingestor(ingestor),
@@ -94,6 +90,7 @@ namespace BitFunnel
             throw error;
         }
 
+        // TODO: this library method should not print to std::cout.
         std::cout << "  " << m_filePaths[index] << std::endl;
 
         auto input = m_fileSystem.OpenForRead(m_filePaths[index].c_str(),
@@ -103,8 +100,8 @@ namespace BitFunnel
         {
             std::stringstream message;
             message << "Failed to open chunk file '"
-                << m_filePaths[index]
-                << "'";
+                    << m_filePaths[index]
+                    << "'";
             throw FatalError(message.str());
         }
 
@@ -124,19 +121,12 @@ namespace BitFunnel
             if (m_chunkWriterFactory != nullptr) {
                 chunkWriter = m_chunkWriterFactory->CreateChunkWriter(index);
             }
-            //// Block scopes std::ostream.
-            //std::unique_ptr<std::ostream> output;
-            //if (m_fileManager != nullptr)
-            //{
-            //    output = m_fileManager->Chunk(index).OpenForWrite();
-            //}
 
             ChunkIngestor processor(m_configuration,
                                     m_ingestor,
                                     m_cacheDocuments,
                                     m_filter,
-                                    chunkWriter.get());
-//                                    std::move(output));
+                                    chunkWriter.get());     // TODO: consider std::move chunkwriter to processor.
 
             ChunkReader(&chunkData[0],
                         &chunkData[0] + chunkData.size(),

--- a/src/Chunks/src/ChunkManifestIngestor.cpp
+++ b/src/Chunks/src/ChunkManifestIngestor.cpp
@@ -117,6 +117,7 @@ namespace BitFunnel
 
         {
             // Block scopes IChunkWriter.
+            // IChunkWriter's destructor zero-terminates its output and closes its stream.
             std::unique_ptr<IChunkWriter> chunkWriter;
             if (m_chunkWriterFactory != nullptr) {
                 chunkWriter = m_chunkWriterFactory->CreateChunkWriter(index);

--- a/src/Chunks/src/ChunkManifestIngestor.h
+++ b/src/Chunks/src/ChunkManifestIngestor.h
@@ -33,7 +33,6 @@ namespace BitFunnel
     class IConfiguration;
     class IChunkWriterFactory;
     class IDocumentFilter;
-    class IFileManager;
     class IFileSystem;
     class IIngestor;
 
@@ -43,7 +42,6 @@ namespace BitFunnel
     public:
         ChunkManifestIngestor(IFileSystem & fileSystem,
                               IChunkWriterFactory* chunkWriterFactory,
-//                              IFileManager * fileManager,
                               std::vector<std::string> const & filePaths,
                               IConfiguration const & config,
                               IIngestor & ingestor,
@@ -66,7 +64,6 @@ namespace BitFunnel
 
         IFileSystem & m_fileSystem;
         IChunkWriterFactory * m_chunkWriterFactory;
-//        IFileManager * m_fileManager;
         std::vector<std::string> const & m_filePaths;
         IConfiguration const & m_configuration;
         IIngestor& m_ingestor;

--- a/src/Chunks/src/ChunkManifestIngestor.h
+++ b/src/Chunks/src/ChunkManifestIngestor.h
@@ -37,9 +37,49 @@ namespace BitFunnel
     class IIngestor;
 
 
+    //*************************************************************************
+    //
+    // ChunkManifestIngestor
+    //
+    // Uses the BitFunnel ingestion pipeline to process a set of chunk/corpus
+    // files into a stream of IDocuments, which are then be filtered and then
+    // either written to disk or ingested into the index.
+    //
+    //*************************************************************************
     class ChunkManifestIngestor : public IChunkManifestIngestor
     {
     public:
+        // Constructor parameters:
+        //   fileSystem: the filesystem that hosts the input chunks.
+        //
+        //   chunkWriterFactory:
+        //     If supplied, this factory's writers will be used be used to
+        //     write documents that make it through the filter. If nullptr
+        //     is passed, the documents will be ingested into the
+        //     index. Writers have the opportunity to modify or annotate
+        //     the document before writing. One use case is adding pseudo
+        //     terms that indicate which shard holds a document.
+        //
+        //   filePaths:
+        //      A vector of paths to input chunk files.
+        //
+        //   config:
+        //      The IConfiguration that specifies ingestion parameters
+        //      (e.g. maximum n-gram size).
+        //
+        //   ingestor:
+        //      The IIngestor for the current index.
+        //
+        //   filter:
+        //      An IDocumentFilter that determines which documents
+        //      will be processed (copied or ingested).
+        //
+        //   cacheDocuments:
+        //      If true, ingested documents will also be stored in a
+        //      cache in order to allow for query verification with
+        //      the `verify one` and `verify log` commands in the
+        //      BitFunnel repl.
+        //
         ChunkManifestIngestor(IFileSystem & fileSystem,
                               IChunkWriterFactory* chunkWriterFactory,
                               std::vector<std::string> const & filePaths,

--- a/src/Chunks/src/ChunkManifestIngestor.h
+++ b/src/Chunks/src/ChunkManifestIngestor.h
@@ -31,16 +31,19 @@
 namespace BitFunnel
 {
     class IConfiguration;
+    class IChunkWriterFactory;
     class IDocumentFilter;
     class IFileManager;
     class IFileSystem;
     class IIngestor;
 
+
     class ChunkManifestIngestor : public IChunkManifestIngestor
     {
     public:
         ChunkManifestIngestor(IFileSystem & fileSystem,
-                              IFileManager * fileManager,
+                              IChunkWriterFactory* chunkWriterFactory,
+//                              IFileManager * fileManager,
                               std::vector<std::string> const & filePaths,
                               IConfiguration const & config,
                               IIngestor & ingestor,
@@ -62,7 +65,8 @@ namespace BitFunnel
         //
 
         IFileSystem & m_fileSystem;
-        IFileManager * m_fileManager;
+        IChunkWriterFactory * m_chunkWriterFactory;
+//        IFileManager * m_fileManager;
         std::vector<std::string> const & m_filePaths;
         IConfiguration const & m_configuration;
         IIngestor& m_ingestor;

--- a/src/Chunks/src/ChunkReader.cpp
+++ b/src/Chunks/src/ChunkReader.cpp
@@ -59,10 +59,7 @@ namespace BitFunnel
 
         Consume(0);
 
-        // TODO: Is is bad to pass nullptr?
-//        ChunkWriter writer(nullptr, nullptr);
         m_processor.OnFileExit();
-//        m_processor.OnFileExit(writer);
     }
 
 
@@ -85,11 +82,6 @@ namespace BitFunnel
 
         m_processor.OnDocumentExit(start,
                                    static_cast<size_t>(m_next - start));
-
-        //ChunkWriter writer(start, m_next);
-
-        //m_processor.OnDocumentExit(writer,
-        //                           static_cast<size_t>(m_next - start));
     }
 
 
@@ -204,29 +196,4 @@ namespace BitFunnel
 
         GetChar();
     }
-
-
-    ////*************************************************************************
-    ////
-    //// ChunkReader::ChunkWriter
-    ////
-    ////*************************************************************************
-    //ChunkReader::ChunkWriter::ChunkWriter(char const * start,
-    //                                      char const * end)
-    //  : m_start(start),
-    //    m_end(end)
-    //{
-    //}
-
-
-    //void ChunkReader::ChunkWriter::Write(std::ostream & output)
-    //{
-    //    output.write(m_start, m_end - m_start);
-    //}
-
-
-    //void ChunkReader::ChunkWriter::Complete(std::ostream & output)
-    //{
-    //    output << '\0';
-    //}
 }

--- a/src/Chunks/src/ChunkReader.cpp
+++ b/src/Chunks/src/ChunkReader.cpp
@@ -60,8 +60,9 @@ namespace BitFunnel
         Consume(0);
 
         // TODO: Is is bad to pass nullptr?
-        ChunkWriter writer(nullptr, nullptr);
-        m_processor.OnFileExit(writer);
+//        ChunkWriter writer(nullptr, nullptr);
+        m_processor.OnFileExit();
+//        m_processor.OnFileExit(writer);
     }
 
 
@@ -82,10 +83,13 @@ namespace BitFunnel
             throw FatalError("length underflow.");
         }
 
-        ChunkWriter writer(start, m_next);
-
-        m_processor.OnDocumentExit(writer,
+        m_processor.OnDocumentExit(start,
                                    static_cast<size_t>(m_next - start));
+
+        //ChunkWriter writer(start, m_next);
+
+        //m_processor.OnDocumentExit(writer,
+        //                           static_cast<size_t>(m_next - start));
     }
 
 
@@ -202,27 +206,27 @@ namespace BitFunnel
     }
 
 
-    //*************************************************************************
-    //
-    // ChunkReader::ChunkWriter
-    //
-    //*************************************************************************
-    ChunkReader::ChunkWriter::ChunkWriter(char const * start,
-                                          char const * end)
-      : m_start(start),
-        m_end(end)
-    {
-    }
+    ////*************************************************************************
+    ////
+    //// ChunkReader::ChunkWriter
+    ////
+    ////*************************************************************************
+    //ChunkReader::ChunkWriter::ChunkWriter(char const * start,
+    //                                      char const * end)
+    //  : m_start(start),
+    //    m_end(end)
+    //{
+    //}
 
 
-    void ChunkReader::ChunkWriter::Write(std::ostream & output)
-    {
-        output.write(m_start, m_end - m_start);
-    }
+    //void ChunkReader::ChunkWriter::Write(std::ostream & output)
+    //{
+    //    output.write(m_start, m_end - m_start);
+    //}
 
 
-    void ChunkReader::ChunkWriter::Complete(std::ostream & output)
-    {
-        output << '\0';
-    }
+    //void ChunkReader::ChunkWriter::Complete(std::ostream & output)
+    //{
+    //    output << '\0';
+    //}
 }

--- a/src/Chunks/src/ChunkReader.h
+++ b/src/Chunks/src/ChunkReader.h
@@ -25,8 +25,9 @@
 #include <stdint.h>
 #include <vector>
 
-#include "BitFunnel/NonCopyable.h"  // Base class.
-#include "BitFunnel/Term.h"         // Term::StreamId return value.
+#include "BitFunnel/Chunks/IChunkWriter.h"  // Base class.
+#include "BitFunnel/NonCopyable.h"          // Base class.
+#include "BitFunnel/Term.h"                 // Term::StreamId return value.
 
 
 namespace BitFunnel

--- a/src/Chunks/src/ChunkReader.h
+++ b/src/Chunks/src/ChunkReader.h
@@ -22,12 +22,8 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <vector>
-
-#include "BitFunnel/Chunks/IChunkWriter.h"  // Base class.
-#include "BitFunnel/NonCopyable.h"          // Base class.
-#include "BitFunnel/Term.h"                 // Term::StreamId return value.
+#include "BitFunnel/NonCopyable.h"  // Base class.
+#include "BitFunnel/Term.h"         // Term::StreamId return value.
 
 
 namespace BitFunnel
@@ -51,27 +47,6 @@ namespace BitFunnel
                     IChunkProcessor& processor);
 
     private:
-        //class ChunkWriter : public IChunkWriter
-        //{
-        //public:
-        //    ChunkWriter(char const * start,
-        //                char const * end);
-
-        //    // Writes the bytes in range [m_start, m_end) to the specified
-        //    // stream. ChunkReader uses this method to write the range of bytes
-        //    // corresponding to a single document.
-        //    void Write(std::ostream & output) override;
-
-        //    // Writes a single '\0' to the specified stream. ChunkReader uses
-        //    // this method to write the closing `\0` after a sequence of
-        //    // documents.
-        //    void Complete(std::ostream & output) override;
-
-        //private:
-        //    char const * m_start;
-        //    char const * m_end;
-        //};
-
         void ProcessDocument();
         void ProcessStream();
         char const * GetToken();

--- a/src/Chunks/src/ChunkReader.h
+++ b/src/Chunks/src/ChunkReader.h
@@ -51,26 +51,26 @@ namespace BitFunnel
                     IChunkProcessor& processor);
 
     private:
-        class ChunkWriter : public IChunkWriter
-        {
-        public:
-            ChunkWriter(char const * start,
-                        char const * end);
+        //class ChunkWriter : public IChunkWriter
+        //{
+        //public:
+        //    ChunkWriter(char const * start,
+        //                char const * end);
 
-            // Writes the bytes in range [m_start, m_end) to the specified
-            // stream. ChunkReader uses this method to write the range of bytes
-            // corresponding to a single document.
-            void Write(std::ostream & output) override;
+        //    // Writes the bytes in range [m_start, m_end) to the specified
+        //    // stream. ChunkReader uses this method to write the range of bytes
+        //    // corresponding to a single document.
+        //    void Write(std::ostream & output) override;
 
-            // Writes a single '\0' to the specified stream. ChunkReader uses
-            // this method to write the closing `\0` after a sequence of
-            // documents.
-            void Complete(std::ostream & output) override;
+        //    // Writes a single '\0' to the specified stream. ChunkReader uses
+        //    // this method to write the closing `\0` after a sequence of
+        //    // documents.
+        //    void Complete(std::ostream & output) override;
 
-        private:
-            char const * m_start;
-            char const * m_end;
-        };
+        //private:
+        //    char const * m_start;
+        //    char const * m_end;
+        //};
 
         void ProcessDocument();
         void ProcessStream();

--- a/src/Chunks/src/ChunkWriters.cpp
+++ b/src/Chunks/src/ChunkWriters.cpp
@@ -1,0 +1,125 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "BitFunnel/Configuration/IShardDefinition.h"
+#include "BitFunnel/IFileManager.h"
+#include "BitFunnel/Index/IDocument.h"
+
+#include "ChunkWriters.h"
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // CopyingChunkWriter
+    //
+    //*************************************************************************
+    CopyingChunkWriter::CopyingChunkWriter(IFileManager& fileManager, size_t index)
+        : m_output(fileManager.Chunk(index).OpenForWrite())
+    {
+    }
+
+
+    CopyingChunkWriter::~CopyingChunkWriter()
+    {
+        *m_output << '\0';
+    }
+
+
+    void CopyingChunkWriter::Write(IDocument const &, char const * start, size_t length)
+    {
+        m_output->write(start, length);
+    }
+
+
+    //*************************************************************************
+    //
+    // CopyingChunkWriterFactory
+    //
+    //*************************************************************************
+    CopyingChunkWriterFactory::CopyingChunkWriterFactory(IFileManager& fileManager)
+        : m_fileManager(fileManager)
+    {
+    }
+
+
+    std::unique_ptr<IChunkWriter>
+        CopyingChunkWriterFactory::CreateChunkWriter(size_t index)
+    {
+        return std::make_unique<CopyingChunkWriter>(m_fileManager, index);
+    }
+
+
+    //*************************************************************************
+    //
+    // AnnotatingChunkWriter
+    //
+    //*************************************************************************
+    AnnotatingChunkWriter::AnnotatingChunkWriter(
+        IFileManager& fileManager,
+        size_t index,
+        IShardDefinition const & shardDefinition)
+        : CopyingChunkWriter(fileManager, index),
+        m_shardDefinition(shardDefinition)
+    {
+    }
+
+    void AnnotatingChunkWriter::Write(IDocument const & document,
+        char const * start,
+        size_t length)
+    {
+        // We need min/max count info about the shard the document's posting count belongs in
+        // (Note: We add one to the posting count to account for the added shard term)
+        auto shardId = m_shardDefinition.GetShard(document.GetPostingCount() + 1);
+        auto minCount = m_shardDefinition.GetMinPostingCount(shardId);
+        auto maxCount = m_shardDefinition.GetMaxPostingCount(shardId);
+
+        // Write out all of document except last document-ending byte
+        m_output->write(start, length - 1);
+
+        // Write out shard term into stream 00 (default for body)
+        *m_output << "00" << '\0'
+            << "SHARD_" << minCount << "_" << maxCount << '\0' << '\0' << '\0';
+    }
+
+
+    //*************************************************************************
+    //
+    // AnnotatingChunkWriterFactory
+    //
+    //*************************************************************************
+    AnnotatingChunkWriterFactory::AnnotatingChunkWriterFactory(
+        IFileManager& fileManager,
+        IShardDefinition const & shardDefinition)
+        : CopyingChunkWriterFactory(fileManager),
+          m_shardDefinition(shardDefinition)
+    {
+    }
+
+
+    std::unique_ptr<IChunkWriter>
+        AnnotatingChunkWriterFactory::CreateChunkWriter(size_t index)
+    {
+        return std::make_unique<AnnotatingChunkWriter>(m_fileManager, index, m_shardDefinition);
+    }
+}

--- a/src/Chunks/src/ChunkWriters.cpp
+++ b/src/Chunks/src/ChunkWriters.cpp
@@ -66,6 +66,8 @@ namespace BitFunnel
 
     CopyingChunkWriter::~CopyingChunkWriter()
     {
+        // Zero-terminate the stream, indicating that there are no more documents.
+        // The stream itself will be closed when its std::unique_ptr is destructed.
         *m_output << '\0';
     }
 

--- a/src/Chunks/src/ChunkWriters.cpp
+++ b/src/Chunks/src/ChunkWriters.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "BitFunnel/Chunks/Factories.h"
 #include "BitFunnel/Configuration/IShardDefinition.h"
 #include "BitFunnel/IFileManager.h"
 #include "BitFunnel/Index/IDocument.h"
@@ -29,6 +30,29 @@
 
 namespace BitFunnel
 {
+    //*************************************************************************
+    //
+    // Factory methods.
+    //
+    //*************************************************************************
+    std::unique_ptr<IChunkWriterFactory>
+        Factories::CreateCopyingChunkWriterFactory(IFileManager& fileManager)
+    {
+        return std::make_unique<CopyingChunkWriterFactory>(fileManager);
+    }
+
+
+    std::unique_ptr<IChunkWriterFactory>
+        Factories::CreateAnnotatingChunkWriterFactory(
+            IFileManager& fileManager,
+            IShardDefinition const & shardDefinition)
+    {
+        return std::make_unique<AnnotatingChunkWriterFactory>(
+            fileManager,
+            shardDefinition);
+    }
+
+
     //*************************************************************************
     //
     // CopyingChunkWriter

--- a/src/Chunks/src/ChunkWriters.cpp
+++ b/src/Chunks/src/ChunkWriters.cpp
@@ -104,13 +104,13 @@ namespace BitFunnel
         size_t index,
         IShardDefinition const & shardDefinition)
         : CopyingChunkWriter(fileManager, index),
-        m_shardDefinition(shardDefinition)
+          m_shardDefinition(shardDefinition)
     {
     }
 
     void AnnotatingChunkWriter::Write(IDocument const & document,
-        char const * start,
-        size_t length)
+                                      char const * start,
+                                      size_t length)
     {
         // We need min/max count info about the shard the document's posting count belongs in
         // (Note: We add one to the posting count to account for the added shard term)
@@ -144,6 +144,8 @@ namespace BitFunnel
     std::unique_ptr<IChunkWriter>
         AnnotatingChunkWriterFactory::CreateChunkWriter(size_t index)
     {
-        return std::make_unique<AnnotatingChunkWriter>(m_fileManager, index, m_shardDefinition);
+        return std::make_unique<AnnotatingChunkWriter>(m_fileManager,
+                                                       index,
+                                                       m_shardDefinition);
     }
 }

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -79,6 +79,9 @@ namespace BitFunnel
                            size_t length) override;
 
     protected:
+        // WARNING: The design of this class relies on the output stream being
+        // destructed automatically. The output stream must be destructed in
+        // order to close the its underlying file.
         std::unique_ptr<std::ostream> m_output;
     };
 

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -1,0 +1,126 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <iosfwd>                   // std::ostream template parameter.
+#include <memory>                   // std::unique_ptr<T> parameter.
+#include <stddef.h>                 // size_t parameter.
+
+#include "BitFunnel/IInterface.h"   // Base class.
+#include "BitFunnel/NonCopyable.h"  // Base class.
+
+
+namespace BitFunnel
+{
+    class IDocument;
+    class IFileManager;
+    class IShardDefinition;
+
+
+    class IChunkWriter : public IInterface, NonCopyable
+    {
+    public:
+        virtual void Write(IDocument const & document,
+                           char const * start,
+                           size_t length) = 0;
+    };
+
+
+    class CopyingChunkWriter : public IChunkWriter
+    {
+    public:
+        CopyingChunkWriter(IFileManager& fileManager, size_t index);
+        virtual ~CopyingChunkWriter();
+
+
+        //
+        // IChunkWriter methods
+        //
+
+        virtual void Write(IDocument const & document,
+                           char const * start,
+                           size_t length) override;
+
+    protected:
+        std::unique_ptr<std::ostream> m_output;
+    };
+
+
+    class AnnotatingChunkWriter : public CopyingChunkWriter
+    {
+    public:
+        AnnotatingChunkWriter(IFileManager& fileManager,
+                              size_t index,
+                              IShardDefinition const & shardDefinition);
+
+        //
+        // IChunkWriter methods
+        //
+
+        virtual void Write(IDocument const & document,
+                           char const * start,
+                           size_t length) override;
+
+    private:
+        IShardDefinition const & m_shardDefinition;
+    };
+
+
+    class IChunkWriterFactory : public IInterface, NonCopyable
+    {
+    public:
+        virtual std::unique_ptr<IChunkWriter>
+            CreateChunkWriter(size_t index) = 0;
+    };
+
+
+    class CopyingChunkWriterFactory : public IChunkWriterFactory
+    {
+    public:
+        CopyingChunkWriterFactory(IFileManager& fileManager);
+
+        //
+        // IChunkWriterFactory methods.
+        //
+
+        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
+ 
+    protected:
+        IFileManager & m_fileManager;
+    };
+
+
+    class AnnotatingChunkWriterFactory : public CopyingChunkWriterFactory
+    {
+    public:
+        AnnotatingChunkWriterFactory(IFileManager& fileManager,
+                                     IShardDefinition const & shardDefinition);
+
+        //
+        // IChunkWriterFactory methods.
+        //
+
+        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
+
+    private:
+        IShardDefinition const & m_shardDefinition;
+    };
+}

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -22,12 +22,13 @@
 
 #pragma once
 
-#include <iosfwd>                   // std::ostream template parameter.
-#include <memory>                   // std::unique_ptr<T> parameter.
-#include <stddef.h>                 // size_t parameter.
+#include <iosfwd>                           // std::ostream template parameter.
+#include <memory>                           // std::unique_ptr<T> parameter.
+#include <stddef.h>                         // size_t parameter.
 
-#include "BitFunnel/IInterface.h"   // Base class.
-#include "BitFunnel/NonCopyable.h"  // Base class.
+#include "BitFunnel/Chunks/IChunkWriter.h"  // Base class.
+//#include "BitFunnel/IInterface.h"           // Base class.
+//#include "BitFunnel/NonCopyable.h"          // Base class.
 
 
 namespace BitFunnel
@@ -37,13 +38,13 @@ namespace BitFunnel
     class IShardDefinition;
 
 
-    class IChunkWriter : public IInterface, NonCopyable
-    {
-    public:
-        virtual void Write(IDocument const & document,
-                           char const * start,
-                           size_t length) = 0;
-    };
+    //class IChunkWriter : public IInterface, NonCopyable
+    //{
+    //public:
+    //    virtual void Write(IDocument const & document,
+    //                       char const * start,
+    //                       size_t length) = 0;
+    //};
 
 
     class CopyingChunkWriter : public IChunkWriter
@@ -86,12 +87,12 @@ namespace BitFunnel
     };
 
 
-    class IChunkWriterFactory : public IInterface, NonCopyable
-    {
-    public:
-        virtual std::unique_ptr<IChunkWriter>
-            CreateChunkWriter(size_t index) = 0;
-    };
+    //class IChunkWriterFactory : public IInterface, NonCopyable
+    //{
+    //public:
+    //    virtual std::unique_ptr<IChunkWriter>
+    //        CreateChunkWriter(size_t index) = 0;
+    //};
 
 
     class CopyingChunkWriterFactory : public IChunkWriterFactory

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -40,6 +40,9 @@ namespace BitFunnel
     //
     // CopyingChunkWriterFactory
     //
+    // Generates CopyingChunkWriters that write chunk files to paths supplied
+    // by an IFileManager.
+    //
     //*************************************************************************
     class CopyingChunkWriterFactory : public IChunkWriterFactory
     {
@@ -61,6 +64,10 @@ namespace BitFunnel
     //*************************************************************************
     //
     // CopyingChunkWriter
+    //
+    // Writes chunk files to paths supplied by an IFileManager.
+    // Primary use case is copying certain documents from one chunk file
+    // to another.
     //
     //*************************************************************************
     class CopyingChunkWriter : public IChunkWriter
@@ -90,6 +97,10 @@ namespace BitFunnel
     //
     // AnnotatingChunkWriterFactory
     //
+    // Generates AnnotatingChunkWriters that write annotated chunk files to
+    // paths supplied by an IFileManager. Each document is annotated with a
+    // pseudo term indicating its shard.
+    //
     //*************************************************************************
     class AnnotatingChunkWriterFactory : public CopyingChunkWriterFactory
     {
@@ -112,6 +123,16 @@ namespace BitFunnel
     //*************************************************************************
     //
     // AnnotatingChunkWriter
+    //
+    // Writes chunk files to paths supplied by an IFileManager.
+    // Each document is annotated with a pseudo-term that indicates the
+    // document's shard. The term is added to stream `00` and take the form
+    //     SHARD_min_max
+    // where `min` and `max` are the shard parameters denoting the range of
+    // unique term counts allowed in the shard: [min, max).
+    //
+    // Primary use case is annotating documents with shard info, in order to
+    // facilitate measurement and verification of shard-specific query results.
     //
     //*************************************************************************
     class AnnotatingChunkWriter : public CopyingChunkWriter

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -27,8 +27,6 @@
 #include <stddef.h>                         // size_t parameter.
 
 #include "BitFunnel/Chunks/IChunkWriter.h"  // Base class.
-//#include "BitFunnel/IInterface.h"           // Base class.
-//#include "BitFunnel/NonCopyable.h"          // Base class.
 
 
 namespace BitFunnel
@@ -38,15 +36,33 @@ namespace BitFunnel
     class IShardDefinition;
 
 
-    //class IChunkWriter : public IInterface, NonCopyable
-    //{
-    //public:
-    //    virtual void Write(IDocument const & document,
-    //                       char const * start,
-    //                       size_t length) = 0;
-    //};
+    //*************************************************************************
+    //
+    // CopyingChunkWriterFactory
+    //
+    //*************************************************************************
+    class CopyingChunkWriterFactory : public IChunkWriterFactory
+    {
+    public:
+        CopyingChunkWriterFactory(IFileManager& fileManager);
 
 
+        //
+        // IChunkWriterFactory methods.
+        //
+
+        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
+
+    protected:
+        IFileManager & m_fileManager;
+    };
+
+
+    //*************************************************************************
+    //
+    // CopyingChunkWriter
+    //
+    //*************************************************************************
     class CopyingChunkWriter : public IChunkWriter
     {
     public:
@@ -67,6 +83,34 @@ namespace BitFunnel
     };
 
 
+    //*************************************************************************
+    //
+    // AnnotatingChunkWriterFactory
+    //
+    //*************************************************************************
+    class AnnotatingChunkWriterFactory : public CopyingChunkWriterFactory
+    {
+    public:
+        AnnotatingChunkWriterFactory(IFileManager& fileManager,
+            IShardDefinition const & shardDefinition);
+
+
+        //
+        // IChunkWriterFactory methods.
+        //
+
+        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
+
+    private:
+        IShardDefinition const & m_shardDefinition;
+    };
+
+
+    //*************************************************************************
+    //
+    // AnnotatingChunkWriter
+    //
+    //*************************************************************************
     class AnnotatingChunkWriter : public CopyingChunkWriter
     {
     public:
@@ -81,47 +125,6 @@ namespace BitFunnel
         virtual void Write(IDocument const & document,
                            char const * start,
                            size_t length) override;
-
-    private:
-        IShardDefinition const & m_shardDefinition;
-    };
-
-
-    //class IChunkWriterFactory : public IInterface, NonCopyable
-    //{
-    //public:
-    //    virtual std::unique_ptr<IChunkWriter>
-    //        CreateChunkWriter(size_t index) = 0;
-    //};
-
-
-    class CopyingChunkWriterFactory : public IChunkWriterFactory
-    {
-    public:
-        CopyingChunkWriterFactory(IFileManager& fileManager);
-
-        //
-        // IChunkWriterFactory methods.
-        //
-
-        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
- 
-    protected:
-        IFileManager & m_fileManager;
-    };
-
-
-    class AnnotatingChunkWriterFactory : public CopyingChunkWriterFactory
-    {
-    public:
-        AnnotatingChunkWriterFactory(IFileManager& fileManager,
-                                     IShardDefinition const & shardDefinition);
-
-        //
-        // IChunkWriterFactory methods.
-        //
-
-        virtual std::unique_ptr<IChunkWriter> CreateChunkWriter(size_t index) override;
 
     private:
         IShardDefinition const & m_shardDefinition;

--- a/src/Chunks/src/ChunkWriters.h
+++ b/src/Chunks/src/ChunkWriters.h
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#pragma once
+
 #include <iosfwd>                   // std::ostream template parameter.
 #include <memory>                   // std::unique_ptr<T> parameter.
 #include <stddef.h>                 // size_t parameter.

--- a/src/Chunks/test/ChunkEventTracer.h
+++ b/src/Chunks/test/ChunkEventTracer.h
@@ -94,14 +94,17 @@ namespace BitFunnel
             }
 
 
-            void OnDocumentExit(IChunkWriter & /*writer*/,
-                                size_t /*sourceByteSize*/) override
+            //void OnDocumentExit(IChunkWriter & /*writer*/,
+            //                    size_t /*sourceByteSize*/) override
+            void OnDocumentExit(char const *,
+                                size_t) override
             {
                 m_trace << "OnDocumentExit" << std::endl;
             }
 
 
-            void OnFileExit(IChunkWriter & /*writer*/) override
+//            void OnFileExit(IChunkWriter & /*writer*/) override
+            void OnFileExit() override
             {
                 m_trace << "OnFileExit" << std::endl;
             }

--- a/src/Chunks/test/ChunkEventTracer.h
+++ b/src/Chunks/test/ChunkEventTracer.h
@@ -25,8 +25,8 @@
 
 #include <sstream>
 
-#include "BitFunnel/Chunks/IChunkProcessor.h"
-#include "ChunkReader.h"
+#include "BitFunnel/Chunks/IChunkProcessor.h"   // Base class.
+#include "ChunkReader.h"                        // Inline method.
 
 
 namespace BitFunnel
@@ -73,7 +73,7 @@ namespace BitFunnel
             void OnStreamEnter(Term::StreamId id) override
             {
                 m_trace << "OnStreamEnter;streamId: "
-                        // Cast to uint64_T that operator<< won't treat uin8_t a char.
+                        // Cast to uint64_t so that operator<< won't treat uin8_t a char.
                         << static_cast<uint64_t>(id)
                         << std::endl;
             }
@@ -94,8 +94,6 @@ namespace BitFunnel
             }
 
 
-            //void OnDocumentExit(IChunkWriter & /*writer*/,
-            //                    size_t /*sourceByteSize*/) override
             void OnDocumentExit(char const *,
                                 size_t) override
             {
@@ -103,7 +101,6 @@ namespace BitFunnel
             }
 
 
-//            void OnFileExit(IChunkWriter & /*writer*/) override
             void OnFileExit() override
             {
                 m_trace << "OnFileExit" << std::endl;

--- a/src/Index/src/Ingestor.cpp
+++ b/src/Index/src/Ingestor.cpp
@@ -254,6 +254,12 @@ namespace BitFunnel
     }
 
 
+    IShardDefinition const & Ingestor::GetShardDefinition() const
+    {
+        return m_shardDefinition;
+    }
+
+
     ITokenManager& Ingestor::GetTokenManager() const
     {
         return *m_tokenManager;

--- a/src/Index/src/Ingestor.h
+++ b/src/Index/src/Ingestor.h
@@ -133,6 +133,8 @@ namespace BitFunnel
         virtual size_t GetShardCount() const override;
         virtual IShard& GetShard(size_t shard) const override;
 
+        virtual IShardDefinition const & GetShardDefinition() const override;
+
         virtual IRecycler& GetRecycler() const override;
 
         virtual ITokenManager& GetTokenManager() const override;

--- a/tools/BitFunnel/src/FilterChunks.cpp
+++ b/tools/BitFunnel/src/FilterChunks.cpp
@@ -28,6 +28,7 @@
 #include "BitFunnel/Chunks/DocumentFilters.h"
 #include "BitFunnel/Chunks/Factories.h"
 #include "BitFunnel/Chunks/IChunkManifestIngestor.h"
+#include "BitFunnel/Chunks/IChunkWriter.h"
 #include "BitFunnel/Configuration/IFileSystem.h"
 #include "BitFunnel/Exceptions.h"
 #include "BitFunnel/Index/Factories.h"
@@ -210,9 +211,13 @@ namespace BitFunnel
             outputDirectory,
             index->GetFileSystem());
 
+        auto chunkWriterFactory =
+            Factories::CreateCopyingChunkWriterFactory(*fileManager);
+
         auto manifest = Factories::CreateChunkManifestIngestor(
             m_fileSystem,
-            fileManager.get(),
+            chunkWriterFactory.get(),
+//            fileManager.get(),
             filePaths,
             configuration,
             ingestor,

--- a/tools/BitFunnel/src/FilterChunks.cpp
+++ b/tools/BitFunnel/src/FilterChunks.cpp
@@ -114,7 +114,7 @@ namespace BitFunnel
 
         CmdLine::OptionalParameter<const char *> writer(
             "writer",
-            "Alternative chunk writer (annotate or copy)",
+            "Specify chunk writer (annotate or copy)",
             "copy");
 
 
@@ -219,7 +219,7 @@ namespace BitFunnel
             outputDirectory,
             index->GetFileSystem());
 
-        // Select IChunkWriterFactory based on name.
+        // Select IChunkWriterFactory based on name provided on command line.
         std::unique_ptr<IChunkWriterFactory> chunkWriterFactory;
         if (!strcmp(writer, "copy"))
         {

--- a/tools/BitFunnel/src/FilterChunks.cpp
+++ b/tools/BitFunnel/src/FilterChunks.cpp
@@ -169,9 +169,13 @@ namespace BitFunnel
 
                 returnCode = 0;
             }
-            catch (RecoverableError e)
+            catch (std::exception e)
             {
                 output << "Error: " << e.what() << std::endl;
+            }
+            catch (Logging::CheckException e)
+            {
+                output << "Error: " << e.GetMessage().c_str() << std::endl;
             }
             catch (...)
             {

--- a/tools/BitFunnel/src/FilterChunks.cpp
+++ b/tools/BitFunnel/src/FilterChunks.cpp
@@ -217,7 +217,6 @@ namespace BitFunnel
         auto manifest = Factories::CreateChunkManifestIngestor(
             m_fileSystem,
             chunkWriterFactory.get(),
-//            fileManager.get(),
             filePaths,
             configuration,
             ingestor,

--- a/tools/BitFunnel/src/FilterChunks.h
+++ b/tools/BitFunnel/src/FilterChunks.h
@@ -26,6 +26,7 @@
 
 namespace BitFunnel
 {
+    class IChunkWriterFactory;
     class IDocumentFilter;
     class IFileSystem;
 
@@ -57,7 +58,8 @@ namespace BitFunnel
             char const * intermediateDirectory,
             char const * chunkListFileName,
             int gramSize,
-            IDocumentFilter & filter) const;
+            IDocumentFilter & filter,
+            char const * writer) const;
 
         IFileSystem& m_fileSystem;
     };

--- a/tools/BitFunnel/src/FilterChunks.h
+++ b/tools/BitFunnel/src/FilterChunks.h
@@ -37,6 +37,7 @@ namespace BitFunnel
     // An IExecutable that copies a set of chunk files specified by a manifest,
     // while filtering the documents based on a set of predicates, including
     // random sampling, posting count in range, and total number of documents.
+    // Can also annotate each document with a pseudo-term indicating its shard.
     //
     //*************************************************************************
     class FilterChunks : public IExecutable


### PR DESCRIPTION
With this change, use of the `-writer annotate` option will output chunks which have an extra shard term injected into every document. It appends an extra '00' stream that holds a single term that identifies the shard (e.g., SHARD_2048_4096).

The default `-writer copy` makes no changes to the documents it copies to the new folder.

This change also avoids index building (ingestion) whenever a writer is used (which filter always does but repl does not).