### PR TITLE
Ensure slices are sized so they fit in requested/default memory

### DIFF
--- a/src/Index/src/Helpers.cpp
+++ b/src/Index/src/Helpers.cpp
@@ -29,6 +29,9 @@
 
 namespace BitFunnel
 {
+    // This calculates the minimum acceptable slice size.
+    // This scales up based on corpus size, since a larger corpus requires more ranks.
+    // Each additional rank doubles the minimum document capacity required for a slice.
     size_t GetMinimumBlockSize(IDocumentDataSchema const & schema,
                                ITermTable const & termTable)
     {
@@ -42,12 +45,11 @@ namespace BitFunnel
     }
 
 
-    // TODO: this should actually be much larger when the corpus is much larger
-    // for performance reasons.
+    // Use minimum block size as a reasonable slice size, since it scales based on corpus size.
     size_t GetReasonableBlockSize(IDocumentDataSchema const & schema,
                                   ITermTable const & termTable)
     {
         size_t minimumFunctionalSize = GetMinimumBlockSize(schema, termTable);
-        return RoundUp<size_t>(minimumFunctionalSize, c_bitsPerPage);           // Why is this bitsPerPage and not bytesPerPage?
+        return RoundUp<size_t>(minimumFunctionalSize, c_bytesPerPage);
     }
 }

--- a/src/Index/src/SimpleIndex.cpp
+++ b/src/Index/src/SimpleIndex.cpp
@@ -357,11 +357,11 @@ namespace BitFunnel
         if (m_sliceAllocator.get() == nullptr)
         {
             // To calculate a large-enough m_blocksize, we need to calculate the
-            // largest blocksize required by any TermTable.
+            // largest blocksize (slice) required by any TermTable (shard).
             size_t m_blockSize = 0;
             for (size_t tableId=0; tableId < m_termTables->size(); ++tableId)
             {
-                const size_t tblBlockSize = 32 * GetReasonableBlockSize(*m_schema, m_termTables->GetTermTable(tableId));
+                const size_t tblBlockSize = GetReasonableBlockSize(*m_schema, m_termTables->GetTermTable(tableId));
                 if (tblBlockSize > m_blockSize)
                 {
                     m_blockSize = tblBlockSize;


### PR DESCRIPTION
The maximum slice need not be multiplied by 32 in order to be large enough to service a large corpus like Gov2 well. It is sufficient to use the maximum slice size required by any shard.

Slice size should be aligned to a page boundary, but need not be aligned to an 8-page boundary.

Rather than defaulting to 512 slices, SimpleIndex defaults to using 1GB memory, if no memory size has been specified.  This addresses https://github.com/BitFunnel/BitFunnel/issues/388.