### PR TITLE
Improve error handling of queries

### DIFF
--- a/src/Plan/src/QueryParser.cpp
+++ b/src/Plan/src/QueryParser.cpp
@@ -200,7 +200,17 @@ namespace BitFunnel
             grams.AddString(token);
         }
 
-        return TermMatchNode::Builder::CreatePhraseNode(grams, streamId, m_allocator);
+        // A phrase must have at least 2 terms.
+        if (grams.GetSize() >= 2)
+        {
+            return TermMatchNode::Builder::CreatePhraseNode(grams, streamId, m_allocator);
+        }
+        else
+        {
+            // TODO: Treat single term phrase as a Unigram (issue #417), e.g.:
+            // return TermMatchNode::Builder::CreateUnigramNode(grams[0], streamId, m_allocator);
+            throw ParseError("A phrase in double-quotes must have at least two terms", m_currentPosition);
+        }
     }
 
 

--- a/src/Plan/src/TermMatchNode.cpp
+++ b/src/Plan/src/TermMatchNode.cpp
@@ -340,7 +340,7 @@ namespace BitFunnel
         : m_streamId(streamId),
           m_grams(grams)
     {
-        LogAssertB(m_grams.GetSize() >= 2, "Phase mush have at least 2 terms.");
+        LogAssertB(m_grams.GetSize() >= 2, "Phrase must have at least 2 terms.");
     }
 
 
@@ -352,7 +352,7 @@ namespace BitFunnel
                    StringVector::Parse(parser, c_defaultInitialCapacity)))
     {
         // Phrase nodes must have at least two Terms.
-        LogAssertB(m_grams.GetSize() >= 2, "Phase mush have at least 2 terms.");
+        LogAssertB(m_grams.GetSize() >= 2, "Phrase must have at least 2 terms.");
         parser.CloseObject();
     }
 


### PR DESCRIPTION
* The REPL `query` command is wrapped in a try block that catches RecoverableErrors
* An invalid `query` option stuffs the error message within the RecoverableError
* A 1-gram phrase throws a recoverable ParseError (with comment showing how to handle this without error as a 1-gram term)