### PR TITLE
Enable BitFunnel REPL 'show' to iterate results over specified 'shard'(s)

### DIFF
--- a/inc/BitFunnel/Index/IIngestor.h
+++ b/inc/BitFunnel/Index/IIngestor.h
@@ -128,6 +128,9 @@ namespace BitFunnel
         // Returns the number of documents currently active in the index.
         virtual size_t GetDocumentCount() const = 0;
 
+        // Returns the maximum DocID of any document added to the index.
+        virtual DocId GetMaxDocId() const = 0;
+
         // Returns the size in bytes of the capacity of row tables in the
         // entire ingestion index.
         virtual size_t GetUsedCapacityInBytes() const = 0;

--- a/src/Index/src/Ingestor.cpp
+++ b/src/Index/src/Ingestor.cpp
@@ -65,6 +65,7 @@ namespace BitFunnel
           // But see issue 389. Because of that issue, m_documentCount is not
           // always equal to m_documentMap.size().
           m_documentCount(0),
+          m_maxDocId(0),
           m_totalSourceByteSize(0),
           m_documentMap(new DocumentMap()),
           m_documentCache(new DocumentCache()),
@@ -178,6 +179,7 @@ namespace BitFunnel
     {
         ++m_documentCount;
         m_totalSourceByteSize += document.GetSourceByteSize();
+        m_maxDocId = id > m_maxDocId ? id : m_maxDocId;
 
         // Add postingCount to the DocumentHistogramBuilder
         m_histogram.AddDocument(document.GetPostingCount());
@@ -328,6 +330,12 @@ namespace BitFunnel
     {
         return m_documentCount;
 //        return m_documentMap->size();
+    }
+
+
+    DocId Ingestor::GetMaxDocId() const
+    {
+        return m_maxDocId;
     }
 
 

--- a/src/Index/src/Ingestor.cpp
+++ b/src/Index/src/Ingestor.cpp
@@ -179,7 +179,10 @@ namespace BitFunnel
     {
         ++m_documentCount;
         m_totalSourceByteSize += document.GetSourceByteSize();
-        m_maxDocId = id > m_maxDocId ? id : m_maxDocId;
+
+        DocId oldMaxId = m_maxDocId;
+        while (id > oldMaxId &&
+               !m_maxDocId.compare_exchange_weak(oldMaxId, id));
 
         // Add postingCount to the DocumentHistogramBuilder
         m_histogram.AddDocument(document.GetPostingCount());

--- a/src/Index/src/Ingestor.h
+++ b/src/Index/src/Ingestor.h
@@ -131,6 +131,7 @@ namespace BitFunnel
 
         // Returns a number of Shards and a Shard with the given ShardId.
         virtual size_t GetShardCount() const override;
+        virtual DocId GetMaxDocId() const override;
         virtual IShard& GetShard(size_t shard) const override;
 
         virtual IShardDefinition const & GetShardDefinition() const override;
@@ -174,6 +175,7 @@ namespace BitFunnel
         // the size of the unordered_map in m_documentMap. The reason
         // is that documents may have been deleted.
         std::atomic<size_t> m_documentCount;
+        std::atomic<DocId> m_maxDocId;
         std::atomic<size_t> m_totalSourceByteSize;
 
         std::unique_ptr<DocumentMap> m_documentMap;

--- a/tools/BitFunnel/src/CMakeLists.txt
+++ b/tools/BitFunnel/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CPPFILES
     REPL.cpp
     ScriptCommand.cpp
     ShardBuilder.cpp
+    ShardCommand.cpp
     ShowCommand.cpp
     StatisticsBuilder.cpp
     StatusCommand.cpp
@@ -59,6 +60,7 @@ set(PRIVATE_HFILES
     REPL.h
     ScriptCommand.h
     ShardBuilder.h
+    ShardCommand.h
     ShowCommand.h
     StatisticsBuilder.h
     StatusCommand.h

--- a/tools/BitFunnel/src/Environment.cpp
+++ b/tools/BitFunnel/src/Environment.cpp
@@ -35,6 +35,7 @@
 #include "InterpreterCommand.h"
 #include "QueryCommand.h"
 #include "ScriptCommand.h"
+#include "ShardCommand.h"
 #include "ShowCommand.h"
 #include "StatusCommand.h"
 #include "TaskFactory.h"
@@ -66,7 +67,9 @@ namespace BitFunnel
         m_memory(memory),
         m_directory(directory),
         m_gramSize(gramSize),
-        m_output(output)
+        m_output(output),
+        m_minshard(0),
+        m_maxshard(0)
     {
         RegisterCommands();
     }
@@ -87,6 +90,7 @@ namespace BitFunnel
         m_taskFactory->RegisterCommand<Load>();
         m_taskFactory->RegisterCommand<Query>();
         m_taskFactory->RegisterCommand<Script>();
+        m_taskFactory->RegisterCommand<ShardCommand>();
         m_taskFactory->RegisterCommand<Show>();
         m_taskFactory->RegisterCommand<Status>();
         m_taskFactory->RegisterCommand<ThreadsCommand>();
@@ -168,6 +172,22 @@ namespace BitFunnel
         return m_output;
     }
 
+
+    size_t Environment::GetMinShard() const
+    {
+        return m_minshard;
+    }
+
+    size_t Environment::GetMaxShard() const
+    {
+        return m_maxshard;
+    }
+
+    void Environment::SetShards(size_t minshard, size_t maxshard)
+    {
+        m_minshard = minshard;
+        m_maxshard = maxshard;
+    }
 
     size_t Environment::GetThreadCount() const
     {

--- a/tools/BitFunnel/src/Environment.h
+++ b/tools/BitFunnel/src/Environment.h
@@ -66,6 +66,10 @@ namespace BitFunnel
         std::string const & GetOutputDir() const;
         void SetOutputDir(std::string dir);
 
+        size_t GetMinShard() const;
+        size_t GetMaxShard() const;
+        void SetShards(size_t minshard, size_t maxshard);
+
         std::ostream & GetOutputStream() const;
 
         size_t GetThreadCount() const;
@@ -98,5 +102,7 @@ namespace BitFunnel
         size_t m_gramSize;
         std::string m_outputDir;
         std::ostream& m_output;
+        size_t m_minshard;
+        size_t m_maxshard;
     };
 }

--- a/tools/BitFunnel/src/REPL.cpp
+++ b/tools/BitFunnel/src/REPL.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "BitFunnel/Exceptions.h"
+#include "BitFunnel/Index/IIngestor.h"
 #include "BitFunnel/Utilities/ReadLines.h"
 #include "CmdLineParser/CmdLineParser.h"
 #include "Environment.h"
@@ -182,6 +183,7 @@ namespace BitFunnel
             << std::endl;
 
         environment.StartIndex();
+        environment.SetShards(0, environment.GetIngestor().GetShardCount());
 
         Loop(environment,
                 input,

--- a/tools/BitFunnel/src/REPL.cpp
+++ b/tools/BitFunnel/src/REPL.cpp
@@ -183,7 +183,7 @@ namespace BitFunnel
             << std::endl;
 
         environment.StartIndex();
-        environment.SetShards(0, environment.GetIngestor().GetShardCount());
+        environment.SetShards(0, environment.GetIngestor().GetShardCount() - 1);
 
         Loop(environment,
                 input,

--- a/tools/BitFunnel/src/ShardCommand.cpp
+++ b/tools/BitFunnel/src/ShardCommand.cpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2016, Microsoft
+// Copyright (c) 2018, Microsoft
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/BitFunnel/src/ShardCommand.cpp
+++ b/tools/BitFunnel/src/ShardCommand.cpp
@@ -46,7 +46,7 @@ namespace BitFunnel
             if (tokens[0].compare("all") == 0)
             {
                 m_minshard = 0;
-                m_maxshard = environment.GetIngestor().GetShardCount();
+                m_maxshard = environment.GetIngestor().GetShardCount() - 1;
             }
             else
             {

--- a/tools/BitFunnel/src/ShardCommand.cpp
+++ b/tools/BitFunnel/src/ShardCommand.cpp
@@ -1,0 +1,107 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <iostream>
+
+#include "BitFunnel/Exceptions.h"
+#include "BitFunnel/Index/IIngestor.h"
+#include "Environment.h"
+#include "ShardCommand.h"
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // Shard - set shard(s) to show results for
+    //
+    //*************************************************************************
+    ShardCommand::ShardCommand(Environment & environment,
+           Id id,
+           char const * parameters)
+        : TaskBase(environment, id, Type::Synchronous)
+    {
+        auto tokens = TaskFactory::Tokenize(parameters);
+        if (tokens.size() > 0)
+        {
+            if (tokens[0].compare("all") == 0)
+            {
+                m_minshard = 0;
+                m_maxshard = environment.GetIngestor().GetShardCount();
+            }
+            else
+            {
+                m_minshard = std::stoull(tokens[0]);
+                if (tokens.size() > 1)
+                {
+                    m_maxshard = std::stoull(tokens[1]);
+                    if (m_minshard > m_maxshard)
+                    {
+                        RecoverableError error("maxshard must not be less than minshard.");
+                        throw error;
+                    }
+                }
+                else
+                {
+                    m_maxshard = m_minshard;
+                }
+            }
+        }
+        else
+        {
+            RecoverableError error("`shard` expects `all` or a shard number/range.");
+            throw error;
+        }
+    }
+
+
+    void ShardCommand::Execute()
+    {
+        GetEnvironment().SetShards(m_minshard, m_maxshard);
+        if (m_minshard == m_maxshard)
+        {
+            std::cout
+                << "Now showing results for shard " << m_minshard
+                << "." << std::endl;
+        }
+        else
+        {
+            std::cout
+                << "Now showing results for shards "
+                << m_minshard << "-" << m_maxshard
+                << "." << std::endl;
+        }
+    }
+
+
+    ICommand::Documentation ShardCommand::GetDocumentation()
+    {
+        return Documentation(
+            "shard",
+            "Set shard(s) to show results for (e.g., 'show rows')",
+            "shard <minshard> <maxshard>\n"
+            "  Changes the shard(s) to show results for.\n"
+            "  <minshard> may be \"all\" to show results for all shards.\n"
+            "  <maxshard> is optional and may be omitted.\n"
+        );
+    }
+}

--- a/tools/BitFunnel/src/ShardCommand.h
+++ b/tools/BitFunnel/src/ShardCommand.h
@@ -1,0 +1,44 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "TaskBase.h"   // TaskBase base class.
+
+
+namespace BitFunnel
+{
+    class ShardCommand : public TaskBase
+    {
+    public:
+        ShardCommand(Environment & environment,
+           Id id,
+           char const * parameters);
+
+        virtual void Execute() override;
+        static ICommand::Documentation GetDocumentation();
+
+    private:
+        size_t m_minshard;
+        size_t m_maxshard;
+    };
+}

--- a/tools/BitFunnel/src/ShardCommand.h
+++ b/tools/BitFunnel/src/ShardCommand.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2016, Microsoft
+// Copyright (c) 2018, Microsoft
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/BitFunnel/src/ShowCommand.cpp
+++ b/tools/BitFunnel/src/ShowCommand.cpp
@@ -139,9 +139,9 @@ namespace BitFunnel
 
                 // TODO: Come up with a better heuristic for deciding which
                 // bits to display. Current algorithm is to display bits for
-                // the first 64 documents with ids less than 1000000.
+                // the first 64 documents in the shard.
 
-                auto maxDocId = 1000000;
+                auto maxDocId = ingestor.GetMaxDocId();
                 std::vector<DocId> ids;
                 for (DocId id = 0; id <= maxDocId; ++id)
                 {

--- a/tools/BitFunnel/src/ShowCommand.cpp
+++ b/tools/BitFunnel/src/ShowCommand.cpp
@@ -43,8 +43,7 @@ namespace BitFunnel
     Show::Show(Environment & environment,
                Id id,
                char const * parameters)
-        : TaskBase(environment, id, Type::Synchronous),
-          m_shard(0)
+        : TaskBase(environment, id, Type::Synchronous)
     {
         auto tokens = TaskFactory::Tokenize(parameters);
         std::string command;
@@ -57,7 +56,12 @@ namespace BitFunnel
         if (command.compare("cache") == 0)
         {
             m_mode = Mode::Cache;
-            m_term = TaskFactory::GetNextToken(parameters);
+            if (tokens.size() < 2)
+            {
+                RecoverableError error("`show cache` expects a term.");
+                throw error;
+            }
+            m_term = tokens[1];
         }
         else if (command.compare("rows") == 0)
         {
@@ -65,21 +69,23 @@ namespace BitFunnel
             if (tokens.size() < 2)
             {
                 RecoverableError error("`show rows` expects a term.");
+                throw error;
             }
             m_term = tokens[1];
-            if (tokens.size() == 3)
-            {
-                m_shard = std::stoull(tokens[2].c_str());
-            }
         }
         else if (command.compare("term") == 0)
         {
             m_mode = Mode::Term;
-            m_term = TaskFactory::GetNextToken(parameters);
+            if (tokens.size() < 2)
+            {
+                RecoverableError error("`show term` expects a term.");
+                throw error;
+            }
+            m_term = tokens[1];
         }
         else
         {
-            RecoverableError error("`show` command expects \"term\" or \"rows\".");
+            RecoverableError error("`show` command expects \"cache\", \"term\" or \"rows\".");
             throw error;
         }
     }
@@ -116,7 +122,6 @@ namespace BitFunnel
             // TODO: Consider parsing phrase terms here.
             auto & environment = GetEnvironment();
             Term term(m_term.c_str(), 0, environment.GetConfiguration());
-            RowIdSequence rows(term, environment.GetTermTable(m_shard));
 
             output
                 << "Term("
@@ -125,77 +130,86 @@ namespace BitFunnel
 
             IIngestor & ingestor = GetEnvironment().GetIngestor();
 
-
-            // TODO: Come up with a better heuristic for deciding which
-            // bits to display. Current algorithm is to display bits for
-            // the first 64 documents with ids less than 1000000.
-
-            std::vector<DocId> ids;
-            for (DocId id = 0; id <= 1000000; ++id)
+            auto maxshard = environment.GetMaxShard();
+            for (auto shard = environment.GetMinShard(); shard <= maxshard; ++shard)
             {
-                if (ingestor.Contains(id))
-                {
-                    DocumentHandle handle = ingestor.GetHandle(id);
-                    if (handle.GetShardId() == m_shard)
-                    {
-                        ids.push_back(id);
-                        if (ids.size() == 64)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
 
-            // Print out 100s digit of DocId.
-            output << "                 d ";
-            for (auto id : ids)
-            {
-                output << ((id / 100) % 10);
-            }
-            output << std::endl;
-
-            // Print ouf 10s digit of DocId.
-            output << "                 o ";
-            for (auto id : ids)
-            {
-                output << ((id / 10) % 10);
-            }
-            output << std::endl;
-
-            // Print out 1s digit of DocId.
-            output << "                 c ";
-            for (auto id : ids)
-            {
-                output << (id % 10);
-            }
-            output << std::endl;
-
-            // Print out RowIds and their bits.
-            for (auto row : rows)
-            {
                 output
-                    << "  RowId("
-                    << row.GetRank()
-                    << ", "
-                    << std::setw(5)
-                    << row.GetIndex()
-                    << ")";
+                    << "Shard: " << shard << std::endl;
 
-                if (m_mode == Mode::Rows)
+                // TODO: Come up with a better heuristic for deciding which
+                // bits to display. Current algorithm is to display bits for
+                // the first 64 documents with ids less than 1000000.
+
+                auto maxDocId = 1000000;
+                std::vector<DocId> ids;
+                for (DocId id = 0; id <= maxDocId; ++id)
                 {
-                    output << ": ";
-                    for (auto id : ids)
+                    if (ingestor.Contains(id))
                     {
-                        if (ingestor.Contains(id))
+                        DocumentHandle handle = ingestor.GetHandle(id);
+                        if (handle.GetShardId() == shard)
                         {
-                            auto handle = ingestor.GetHandle(id);
-                            output << (handle.GetBit(row) ? "1" : "0");
+                            ids.push_back(id);
+                            if (ids.size() == 64)
+                            {
+                                break;
+                            }
                         }
                     }
                 }
 
+                // Print out 100s digit of DocId.
+                output << "                 d ";
+                for (auto id : ids)
+                {
+                    output << ((id / 100) % 10);
+                }
                 output << std::endl;
+
+                // Print ouf 10s digit of DocId.
+                output << "                 o ";
+                for (auto id : ids)
+                {
+                    output << ((id / 10) % 10);
+                }
+                output << std::endl;
+
+                // Print out 1s digit of DocId.
+                output << "                 c ";
+                for (auto id : ids)
+                {
+                    output << (id % 10);
+                }
+                output << std::endl;
+
+                // Print out RowIds and their bits.
+                RowIdSequence rows(term, environment.GetTermTable(shard));
+                for (auto row : rows)
+                {
+                    output
+                        << "  RowId("
+                        << row.GetRank()
+                        << ", "
+                        << std::setw(5)
+                        << row.GetIndex()
+                        << ")";
+
+                    if (m_mode == Mode::Rows)
+                    {
+                        output << ": ";
+                        for (auto id : ids)
+                        {
+                            if (ingestor.Contains(id))
+                            {
+                                auto handle = ingestor.GetHandle(id);
+                                output << (handle.GetBit(row) ? "1" : "0");
+                            }
+                        }
+                    }
+
+                    output << std::endl;
+                }
             }
         }
     }
@@ -205,14 +219,12 @@ namespace BitFunnel
     {
         return Documentation(
             "show",
-            "Shows information about various data structures. (TODO)",
+            "Shows information about various data structures.",
             "show cache <term>\n"
-            "   | rows <term> [shard = 0]\n"
+            "   | rows <term>\n"
             "   | term <term>\n"
-            //"   | shards\n"
-            //"   | shard <shardid>\n"
-            "  Shows information about various data structures."
-            "  PARTIALLY IMPLEMENTED\n"
+            "  Shows information about various data structures.\n"
+            "  Results are shown for the shard(s) specified by `shard`.\n"
         );
     }
 }

--- a/tools/BitFunnel/src/ShowCommand.h
+++ b/tools/BitFunnel/src/ShowCommand.h
@@ -49,6 +49,5 @@ namespace BitFunnel
     private:
         Mode m_mode;
         std::string m_term;
-        size_t m_shard;
     };
 }


### PR DESCRIPTION
The first commit adds the 'shard' command to the REPL, allowing specification of a single shard number, a range of shards, or 'all' shards.

The second commit modifies the 'show' command to display results only for the specified range of shards. It also corrects some logic and help text issues.

The third commit adds a MaxDocId capability to the ingestor, reducing how many documents 'show' iterates through vs. the arbitrary number 1,000,000. This significantly reduces the delay in displaying 'show' results.

