### PR TITLE
Remove hard-coded shard 0 from main logic

### DIFF
--- a/inc/BitFunnel/Index/ISimpleIndex.h
+++ b/inc/BitFunnel/Index/ISimpleIndex.h
@@ -129,13 +129,6 @@ namespace BitFunnel
         virtual IIngestor & GetIngestor() const = 0;
         virtual IRecycler & GetRecycler() const = 0;
 
-        // TODO: return ITermTableCollection or take ShardId.
-        // GetTermTable0() is a temporary method that makes it easy to spot
-        // all of the places in the code that are not Shard-aware. Intention
-        // is to eliminate GetTermTable0() which will cause compiler errors
-        // that will need to be addressed when moving to a multi-shard
-        // system.
-        virtual ITermTable const & GetTermTable0() const = 0;
         virtual ITermTable const & GetTermTable(ShardId shardId) const = 0;
     };
 }

--- a/src/Index/src/SimpleIndex.cpp
+++ b/src/Index/src/SimpleIndex.cpp
@@ -461,12 +461,6 @@ namespace BitFunnel
     }
 
 
-    ITermTable const & SimpleIndex::GetTermTable0() const
-    {
-        return GetTermTable(0);
-    }
-
-
     ITermTable const & SimpleIndex::GetTermTable(ShardId shardId) const
     {
         EnsureStarted(true);

--- a/src/Index/src/SimpleIndex.h
+++ b/src/Index/src/SimpleIndex.h
@@ -98,7 +98,6 @@ namespace BitFunnel
         virtual IFileSystem & GetFileSystem() const override;
         virtual IIngestor & GetIngestor() const override;
         virtual IRecycler & GetRecycler() const override;
-        virtual ITermTable const & GetTermTable0() const override;
         virtual ITermTable const & GetTermTable(ShardId shardId) const override;
 
     private:

--- a/src/Plan/src/TermMatchTreeConverter.cpp
+++ b/src/Plan/src/TermMatchTreeConverter.cpp
@@ -86,7 +86,7 @@ namespace BitFunnel
 
     const RowMatchNode* TermMatchTreeConverter::BuildDocumentActiveMatchNode()
     {
-        const Term documentActiveDocumentTerm = m_index.GetTermTable0().GetDocumentActiveTerm();
+        const Term documentActiveDocumentTerm = Term(ITermTable::SystemTerm::DocumentActive, 0, 0);
         AbstractRowEnumerator rowEnumerator(documentActiveDocumentTerm, m_planRows);
         LogAssertB(rowEnumerator.MoveNext(), "couldn't find documentActive row.");
 

--- a/src/Plan/test/CodeVerifierBase.cpp
+++ b/src/Plan/test/CodeVerifierBase.cpp
@@ -127,7 +127,7 @@ namespace BitFunnel
                 text,
                 c_streamId,
                 m_index.GetConfiguration(),
-                m_index.GetTermTable0(),
+                m_index.GetTermTable(c_shardId),
                 shard));
     }
 

--- a/tools/BitFunnel/src/StatusCommand.cpp
+++ b/tools/BitFunnel/src/StatusCommand.cpp
@@ -61,6 +61,8 @@ namespace BitFunnel
 
         std::cout << std::endl;
 
+        std::cout << "SHARD " << m_shard << "-->" << std::endl << std::endl;
+
         double bytesPerDocument = 0;
         for (Rank rank = 0; rank < c_maxRankValue; ++rank)
         {
@@ -102,23 +104,28 @@ namespace BitFunnel
         }
         std::cout << "Bits per document: " << bitsPerDocument << std::endl;
 
+        // TODO:  This is document count for corpus vs. shard. totalBits will be incorrect.
         const auto documentCount = GetEnvironment().GetIngestor().GetDocumentCount();
         std::cout << "Document count: " << documentCount << std::endl;
 
         const double totalBits = documentCount * bitsPerDocument;
         std::cout << "Total bits: " << totalBits << std::endl;
 
+        // TODO: This is posting count for corpus vs. shard. bitsPerPosting will be incorrect.
         const auto postingCount = GetEnvironment().GetIngestor().GetPostingCount();
         std::cout << "Posting count: " << postingCount << std::endl;
 
-        const double bitsPerPosting = totalBits / postingCount;
-        std::cout << "Bits per posting: " << bitsPerPosting << std::endl;
+        if (postingCount > 0)
+        {
+            const double bitsPerPosting = totalBits / postingCount;
+            std::cout << "Bits per posting: " << bitsPerPosting << std::endl;
+        }
 
         std::cout << std::endl;
 
         std::cout
             << "Slice capacity: "
-            << GetEnvironment().GetIngestor().GetShard(0).GetSliceCapacity()
+            << GetEnvironment().GetIngestor().GetShard(m_shard).GetSliceCapacity()
             << std::endl;
         std::cout << std::endl;
     }


### PR DESCRIPTION
Most of these changes eliminate the existence and use of ISimpleindex::GetTermTable0.

In two places, the impact is noteworthy:

* TermMatchTreeConverter just wants the Term for ActiveDocument, which is not termtable or shard-specific
* Similarly, QueryResources::EnableCacheLineCounting (not changed) only wants the size of a slice, which is the same across all shards, but for which no other convenient method exists to obtain it, so it is obtained from shard(0).

The Status command also becomes problematic in a multi-shard engine. See https://github.com/BitFunnel/BitFunnel/issues/421 for a description of not-yet-resolved problems.