### PR TITLE
Make system term methods static

### DIFF
--- a/inc/BitFunnel/Index/ITermTable.h
+++ b/inc/BitFunnel/Index/ITermTable.h
@@ -127,11 +127,6 @@ namespace BitFunnel
         // and fact terms.
         virtual PackedRowIdSequence GetRows(const Term& term) const = 0;
 
-        // Getters for system defined terms.
-        virtual Term GetDocumentActiveTerm() const = 0;
-        virtual Term GetMatchAllTerm() const = 0;
-        virtual Term GetMatchNoneTerm() const = 0;
-
         // Enumeration defines the FactHandles for each of the system defined
         // terms. Used by FactSet to generate user-defined handles that don't
         // conflict with system handles.
@@ -143,6 +138,26 @@ namespace BitFunnel
             Last = MatchNone,
             Count = 3
         };
+
+        static Term CreateSystemTerm(SystemTerm term)
+        {
+            return Term(term, 0, 0);
+        }
+
+        static Term GetDocumentActiveTerm()
+        {
+            return CreateSystemTerm(SystemTerm::DocumentActive);
+        }
+
+        static Term GetMatchAllTerm()
+        {
+            return CreateSystemTerm(SystemTerm::MatchAll);
+        }
+
+        static Term GetMatchNoneTerm()
+        {
+            return CreateSystemTerm(SystemTerm::MatchNone);
+        }
 
         // Writes the contents of the ITermTable to a stream.
         virtual void Write(std::ostream& output) const = 0;

--- a/src/Index/src/RowTableDescriptor.cpp
+++ b/src/Index/src/RowTableDescriptor.cpp
@@ -80,7 +80,7 @@ namespace BitFunnel
                GetBufferSize(m_capacity, m_rowCount, m_rank, m_maxRank));
 
         // The "match-all" row needs to be initialized differently.
-        RowIdSequence rows(termTable.GetMatchAllTerm(), termTable);
+        RowIdSequence rows(ITermTable::GetMatchAllTerm(), termTable);
 
         auto it = rows.begin();
         if (it == rows.end())

--- a/src/Index/src/Shard.cpp
+++ b/src/Index/src/Shard.cpp
@@ -42,7 +42,7 @@ namespace BitFunnel
     // Extracts a RowId used to mark documents as active/soft-deleted.
     static RowId RowIdForActiveDocument(ITermTable const & termTable)
     {
-        RowIdSequence rows(termTable.GetDocumentActiveTerm(), termTable);
+        RowIdSequence rows(ITermTable::GetDocumentActiveTerm(), termTable);
 
         auto it = rows.begin();
         if (it == rows.end())
@@ -526,7 +526,7 @@ namespace BitFunnel
         RowTableDescriptor const & rowTable = m_rowTables[rank];
         RowTableDescriptor const & rowTable0 = m_rowTables[0];
 
-        RowIndex active = (*RowIdSequence(m_termTable.GetDocumentActiveTerm(),
+        RowIndex active = (*RowIdSequence(ITermTable::GetDocumentActiveTerm(),
                                           m_termTable).begin()).GetIndex();
 
         std::vector<double> densities;

--- a/src/Index/src/TermTable.cpp
+++ b/src/Index/src/TermTable.cpp
@@ -343,24 +343,6 @@ namespace BitFunnel
     }
 
 
-    Term TermTable::GetDocumentActiveTerm() const
-    {
-        return CreateSystemTerm(SystemTerm::DocumentActive);
-    }
-
-
-    Term TermTable::GetMatchAllTerm() const
-    {
-        return CreateSystemTerm(SystemTerm::MatchAll);
-    }
-
-
-    Term TermTable::GetMatchNoneTerm() const
-    {
-        return CreateSystemTerm(SystemTerm::MatchNone);
-    }
-
-
     RowId TermTable::GetRowIdExplicit(size_t index) const
     {
         if (index >= m_rowIds.size())
@@ -370,12 +352,6 @@ namespace BitFunnel
         }
 
         return m_rowIds[index];
-    }
-
-
-    Term TermTable::CreateSystemTerm(SystemTerm term)
-    {
-        return Term(term, 0, 0);
     }
 
 

--- a/src/Index/src/TermTable.h
+++ b/src/Index/src/TermTable.h
@@ -104,11 +104,6 @@ namespace BitFunnel
         // and fact terms.
         virtual PackedRowIdSequence GetRows(const Term& term) const override;
 
-        // Getters for system defined terms.
-        virtual Term GetDocumentActiveTerm() const override;
-        virtual Term GetMatchAllTerm() const override;
-        virtual Term GetMatchNoneTerm() const override;
-
         //
         // Reader methods called by RowIdSequence::const_iterator.
         //
@@ -141,8 +136,6 @@ namespace BitFunnel
         // at least one (transient and quickly fixed) bug where we called
         // CloseTerm multiple times without calling OpenTerm.
         void EnsureTermOpen(bool value) const;
-
-        static Term CreateSystemTerm(SystemTerm term);
 
         bool m_sealed;
         bool m_termOpen;

--- a/src/Index/test/TermTableTest.cpp
+++ b/src/Index/test/TermTableTest.cpp
@@ -342,7 +342,7 @@ namespace BitFunnel
 
             // Soft Deleted Term
             {
-                RowIdSequence rows(termTable.GetDocumentActiveTerm(), termTable);
+                RowIdSequence rows(ITermTable::GetDocumentActiveTerm(), termTable);
                 auto it = rows.begin();
                 EXPECT_EQ(*it, RowId(0, systemRowStart + ITermTable::SystemTerm::DocumentActive));
 
@@ -354,7 +354,7 @@ namespace BitFunnel
 
             {
                 // Match All Term
-                RowIdSequence rows(termTable.GetMatchAllTerm(), termTable);
+                RowIdSequence rows(ITermTable::GetMatchAllTerm(), termTable);
                 auto it = rows.begin();
                 EXPECT_EQ(*it, RowId(0, systemRowStart + ITermTable::SystemTerm::MatchAll));
 
@@ -366,7 +366,7 @@ namespace BitFunnel
 
             {
                 // Soft Deleted Term
-                RowIdSequence rows(termTable.GetMatchNoneTerm(), termTable);
+                RowIdSequence rows(ITermTable::GetMatchNoneTerm(), termTable);
                 auto it = rows.begin();
                 EXPECT_EQ(*it, RowId(0, systemRowStart + ITermTable::SystemTerm::MatchNone));
 

--- a/src/Plan/src/AbstractRowEnumerator.cpp
+++ b/src/Plan/src/AbstractRowEnumerator.cpp
@@ -75,9 +75,9 @@ namespace BitFunnel
         // Initialize the RowIds for the match-all and match-none terms for all the shards.
         for (ShardId shard = 0; shard < planRows.GetShardCount(); ++shard)
         {
-            RowIdSequence matchAll(planRows.GetTermTable(shard).GetMatchAllTerm(),
+            RowIdSequence matchAll(ITermTable::GetMatchAllTerm(),
                                    planRows.GetTermTable(shard));
-            RowIdSequence matchNone(planRows.GetTermTable(shard).GetMatchNoneTerm(),
+            RowIdSequence matchNone(ITermTable::GetMatchNoneTerm(),
                                     planRows.GetTermTable(shard));
 
             m_matchAllTermRowIds[shard] = *matchAll.begin();

--- a/src/Plan/src/TermMatchTreeConverter.cpp
+++ b/src/Plan/src/TermMatchTreeConverter.cpp
@@ -86,7 +86,7 @@ namespace BitFunnel
 
     const RowMatchNode* TermMatchTreeConverter::BuildDocumentActiveMatchNode()
     {
-        const Term documentActiveDocumentTerm = Term(ITermTable::SystemTerm::DocumentActive, 0, 0);
+        const Term documentActiveDocumentTerm = ITermTable::GetDocumentActiveTerm();
         AbstractRowEnumerator rowEnumerator(documentActiveDocumentTerm, m_planRows);
         LogAssertB(rowEnumerator.MoveNext(), "couldn't find documentActive row.");
 


### PR DESCRIPTION
System terms are not dependent on termtable instance data. This change makes them static methods of ITermTable, co-located with the static enum SystemTerm's they depend on.