### PR TITLE
Enrich REPL "analyze" command to generate more comprehensive density analysis

### DIFF
--- a/inc/BitFunnel/IFileManager.h
+++ b/inc/BitFunnel/IFileManager.h
@@ -89,6 +89,7 @@ namespace BitFunnel
         virtual FileDescriptor0 QueryLog() = 0;
         virtual FileDescriptor0 QueryPipelineStatistics() = 0;
         virtual FileDescriptor0 QuerySummaryStatistics() = 0;
+        virtual FileDescriptor0 RowDensitySummary() = 0;
         virtual FileDescriptor0 ShardDefinition() = 0;
         //virtual FileDescriptor0 ShardDocCounts() = 0;
         //virtual FileDescriptor0 ShardedDocFreqTable() = 0;

--- a/inc/BitFunnel/IFileManager.h
+++ b/inc/BitFunnel/IFileManager.h
@@ -78,7 +78,6 @@ namespace BitFunnel
         //virtual FileDescriptor0 CommonNegatedTerms() = 0;
         //virtual FileDescriptor0 CommonPhrases() = 0;
         //virtual FileDescriptor0 DocFreqTable() = 0;
-        virtual FileDescriptor0 ColumnDensities() = 0;
         virtual FileDescriptor0 ColumnDensitySummary() = 0;
         virtual FileDescriptor0 DocumentHistogram() = 0;
         //virtual FileDescriptor0 L1RankerConfig() = 0;
@@ -109,6 +108,7 @@ namespace BitFunnel
         // These methods return descriptors for files that are parameterized
         // by a shard number.  The returned FileDescriptor1 objects provide
         // methods to generate the file names and open the files.
+        virtual FileDescriptor1 ColumnDensities(size_t shard) = 0;
         virtual FileDescriptor1 Chunk(size_t number) = 0;
         virtual FileDescriptor1 Correlate(size_t shard) = 0;
         virtual FileDescriptor1 CumulativeTermCounts(size_t shard) = 0;

--- a/inc/BitFunnel/Index/IIngestor.h
+++ b/inc/BitFunnel/Index/IIngestor.h
@@ -128,9 +128,6 @@ namespace BitFunnel
         // Returns the number of documents currently active in the index.
         virtual size_t GetDocumentCount() const = 0;
 
-        // Returns the maximum DocID of any document added to the index.
-        virtual DocId GetMaxDocId() const = 0;
-
         // Returns the size in bytes of the capacity of row tables in the
         // entire ingestion index.
         virtual size_t GetUsedCapacityInBytes() const = 0;

--- a/inc/BitFunnel/Index/IShard.h
+++ b/inc/BitFunnel/Index/IShard.h
@@ -32,6 +32,7 @@
 
 namespace BitFunnel
 {
+    class DocumentHandle;
     class IFileManager;
     class ITermToText;
 
@@ -61,6 +62,21 @@ namespace BitFunnel
             ITermToText const * termToText) const = 0;
 
         virtual void TemporaryWriteAllSlices(IFileManager& fileManager) const = 0;
+
+        // Get the document handle for the nth document in a shard
+        // Warning: this method may not be thread-safe.
+        // If the document's slice is recycled, the returned handle
+        // could point to a different document than intended.
+        virtual DocumentHandle GetHandle(size_t docNumber) const = 0;
+
+        // Find next active document in shard, looking first at docNumber
+        // - Return true if found and modify docNumber to position of active document
+        // - Return false if no more active documents
+        // Warning: this method may not be thread-safe.
+        // If the document's slice is recycled, the altered docNumber
+        // may no longer be valid or could reference a different document than intended.
+        virtual bool FindNextActive(size_t& docNumber) const = 0;
+
 
         // Returns an std::vector containing the bit densities for each row in
         // the RowTable with the specified rank. Bit densities are computed

--- a/inc/BitFunnel/Utilities/Accumulator.h
+++ b/inc/BitFunnel/Utilities/Accumulator.h
@@ -53,6 +53,17 @@ namespace BitFunnel
         }
 
 
+        // Reset for a new sequence of values
+        void Reset()
+        {
+            m_count = 0;
+            m_sum = 0;
+            m_sumSquared = 0;
+            m_min = std::numeric_limits<double>::infinity();
+            m_max = -std::numeric_limits<double>::infinity();
+        }
+
+
         // Updates the accumulated statistics the reflect the addition of
         // another value.
         template <typename T>

--- a/src/Common/Configuration/src/FileManager.cpp
+++ b/src/Common/Configuration/src/FileManager.cpp
@@ -53,7 +53,7 @@ namespace BitFunnel
                                    "Chunk",
                                    ".chunk")),
 
-          m_columnDensities(new ParameterizedFile0(fileSystem,
+          m_columnDensities(new ParameterizedFile1(fileSystem,
                                                    statisticsDirectory,
                                                    "ColumnDensities",
                                                    ".csv")),
@@ -137,12 +137,6 @@ namespace BitFunnel
     // FileDescriptor0 files.
     //
 
-    FileDescriptor0 FileManager::ColumnDensities()
-    {
-        return FileDescriptor0(*m_columnDensities);
-    }
-
-
     FileDescriptor0 FileManager::ColumnDensitySummary()
     {
         return FileDescriptor0(*m_columnDensitySummary);
@@ -206,6 +200,12 @@ namespace BitFunnel
     //
     // FileDescriptor1 files.
     //
+
+    FileDescriptor1 FileManager::ColumnDensities(size_t shard)
+    {
+        return FileDescriptor1(*m_columnDensities, shard);
+    }
+
 
     FileDescriptor1 FileManager::Chunk(size_t number)
     {

--- a/src/Common/Configuration/src/FileManager.cpp
+++ b/src/Common/Configuration/src/FileManager.cpp
@@ -103,6 +103,11 @@ namespace BitFunnel
                                      statisticsDirectory,
                                      "RowDensities",
                                      ".csv")),
+          m_rowDensitySummary(
+              new ParameterizedFile0(fileSystem,
+                                     statisticsDirectory,
+                                     "RowDensitySummary",
+                                     ".csv")),
           m_shardDefinition(
               new ParameterizedFile0(fileSystem,
                                      statisticsDirectory,
@@ -171,6 +176,12 @@ namespace BitFunnel
     FileDescriptor0 FileManager::QuerySummaryStatistics()
     {
         return FileDescriptor0(*m_querySummaryStatistics);
+    }
+
+
+    FileDescriptor0 FileManager::RowDensitySummary()
+    {
+        return FileDescriptor0(*m_rowDensitySummary);
     }
 
 

--- a/src/Common/Configuration/src/FileManager.h
+++ b/src/Common/Configuration/src/FileManager.h
@@ -59,6 +59,7 @@ namespace BitFunnel
         virtual FileDescriptor0 QueryLog() override;
         virtual FileDescriptor0 QueryPipelineStatistics() override;
         virtual FileDescriptor0 QuerySummaryStatistics() override;
+        virtual FileDescriptor0 RowDensitySummary() override;
         virtual FileDescriptor0 ShardDefinition() override;
         //virtual FileDescriptor0 ShardDocCounts() override;
         //virtual FileDescriptor0 ShardedDocFreqTable() override;
@@ -102,6 +103,7 @@ namespace BitFunnel
         std::unique_ptr<IParameterizedFile0> m_queryPipelineStatistics;
         std::unique_ptr<IParameterizedFile0> m_querySummaryStatistics;
         std::unique_ptr<IParameterizedFile1> m_rowDensities;
+        std::unique_ptr<IParameterizedFile0> m_rowDensitySummary;
         std::unique_ptr<IParameterizedFile0> m_shardDefinition;
         std::unique_ptr<IParameterizedFile1> m_termTable;
         std::unique_ptr<IParameterizedFile1> m_termTableStatistics;

--- a/src/Common/Configuration/src/FileManager.h
+++ b/src/Common/Configuration/src/FileManager.h
@@ -48,7 +48,6 @@ namespace BitFunnel
         //virtual FileDescriptor0 CommonNegatedTerms() override;
         //virtual FileDescriptor0 CommonPhrases() override;
         //virtual FileDescriptor0 DocFreqTable() override;
-        virtual FileDescriptor0 ColumnDensities() override;
         virtual FileDescriptor0 ColumnDensitySummary() override;
         virtual FileDescriptor0 DocumentHistogram() override;
         //virtual FileDescriptor0 L1RankerConfig() override;
@@ -75,6 +74,7 @@ namespace BitFunnel
         //virtual FileDescriptor0 StrengtheningMetawords() override;
         virtual FileDescriptor0 VerificationResults() override;
 
+        virtual FileDescriptor1 ColumnDensities(size_t shard) override;
         virtual FileDescriptor1 Chunk(size_t number) override;
         virtual FileDescriptor1 Correlate(size_t shard) override;
         virtual FileDescriptor1 CumulativeTermCounts(size_t shard) override;
@@ -90,7 +90,7 @@ namespace BitFunnel
 
     private:
         std::unique_ptr<IParameterizedFile1> m_chunk;
-        std::unique_ptr<IParameterizedFile0> m_columnDensities;
+        std::unique_ptr<IParameterizedFile1> m_columnDensities;
         std::unique_ptr<IParameterizedFile0> m_columnDensitySummary;
         std::unique_ptr<IParameterizedFile1> m_correlate;
         std::unique_ptr<IParameterizedFile1> m_cumulativeTermCounts;

--- a/src/Index/src/Ingestor.cpp
+++ b/src/Index/src/Ingestor.cpp
@@ -65,7 +65,6 @@ namespace BitFunnel
           // But see issue 389. Because of that issue, m_documentCount is not
           // always equal to m_documentMap.size().
           m_documentCount(0),
-          m_maxDocId(0),
           m_totalSourceByteSize(0),
           m_documentMap(new DocumentMap()),
           m_documentCache(new DocumentCache()),
@@ -179,10 +178,6 @@ namespace BitFunnel
     {
         ++m_documentCount;
         m_totalSourceByteSize += document.GetSourceByteSize();
-
-        DocId oldMaxId = m_maxDocId;
-        while (id > oldMaxId &&
-               !m_maxDocId.compare_exchange_weak(oldMaxId, id));
 
         // Add postingCount to the DocumentHistogramBuilder
         m_histogram.AddDocument(document.GetPostingCount());
@@ -333,12 +328,6 @@ namespace BitFunnel
     {
         return m_documentCount;
 //        return m_documentMap->size();
-    }
-
-
-    DocId Ingestor::GetMaxDocId() const
-    {
-        return m_maxDocId;
     }
 
 

--- a/src/Index/src/Ingestor.h
+++ b/src/Index/src/Ingestor.h
@@ -131,7 +131,6 @@ namespace BitFunnel
 
         // Returns a number of Shards and a Shard with the given ShardId.
         virtual size_t GetShardCount() const override;
-        virtual DocId GetMaxDocId() const override;
         virtual IShard& GetShard(size_t shard) const override;
 
         virtual IShardDefinition const & GetShardDefinition() const override;
@@ -175,7 +174,6 @@ namespace BitFunnel
         // the size of the unordered_map in m_documentMap. The reason
         // is that documents may have been deleted.
         std::atomic<size_t> m_documentCount;
-        std::atomic<DocId> m_maxDocId;
         std::atomic<size_t> m_totalSourceByteSize;
 
         std::unique_ptr<DocumentMap> m_documentMap;

--- a/src/Index/src/RowTableAnalyzer.cpp
+++ b/src/Index/src/RowTableAnalyzer.cpp
@@ -99,7 +99,7 @@ namespace BitFunnel
                 *fileSystem);
 
         auto summaryOut = outFileManager->RowDensitySummary().OpenForWrite();
-        *summaryOut << "shard,idx10,rank,mean,min,max,var,count" << std::endl;
+        *summaryOut << "shard,idfx10,rank,mean,min,max,var,count" << std::endl;
 
         for (ShardId shardId = 0; shardId < ingestor.GetShardCount(); ++shardId)
         {
@@ -118,9 +118,9 @@ namespace BitFunnel
         std::ostream& summaryOut) const
     {
         auto & shard = m_index.GetIngestor().GetShard(shardId);
-        std::array<std::vector<double>, c_maxRankValue> densities;
+        std::array<std::vector<double>, c_maxRankValue+1> densities;
 
-        for (Rank rank = 0; rank < c_maxRankValue; ++rank)
+        for (Rank rank = 0; rank <= c_maxRankValue; ++rank)
         {
             densities[rank] = shard.GetDensities(rank);
         }
@@ -222,46 +222,6 @@ namespace BitFunnel
     void RowTableAnalyzer::AnalyzeColumns(char const * outDir) const
     {
         auto & ingestor = m_index.GetIngestor();
-        auto & cache = ingestor.GetDocumentCache();
-
-        std::vector<Column> columns;
-
-        for (auto doc : cache)
-        {
-            const DocumentHandleInternal
-                handle(ingestor.GetHandle(doc.second));
-
-            Slice const & slice = handle.GetSlice();
-            const ShardId shard = slice.GetShard().GetId();
-
-            columns.emplace_back(doc.second,
-                                 shard,
-                                 doc.first.GetPostingCount());
-
-            void const * buffer = slice.GetSliceBuffer();
-            const DocIndex column = handle.GetIndex();
-
-            for (Rank rank = 0; rank <= c_maxRankValue; ++rank)
-            {
-                RowTableDescriptor rowTable = slice.GetRowTable(rank);
-
-                size_t bitCount = 0;
-                const size_t rowCount = rowTable.GetRowCount();
-                for (RowIndex row = 0; row < rowCount; ++row)
-                {
-                    if (rowTable.GetBit(buffer, row, column) != 0)
-                    {
-                        ++bitCount;
-                    }
-                }
-
-                columns.back().SetCount(rank, bitCount);
-
-                double density =
-                    (rowCount == 0) ? 0.0 : static_cast<double>(bitCount) / rowCount;
-                columns.back().SetDensity(rank, density);
-            }
-        }
 
         auto fileSystem = Factories::CreateFileSystem();
         auto outFileManager =
@@ -270,47 +230,81 @@ namespace BitFunnel
                                          outDir,
                                          *fileSystem);
 
-        //
-        // Write out raw column data.
-        //
+        auto summaryOut = outFileManager->ColumnDensitySummary().OpenForWrite();
+        *summaryOut << "shard,rank,mean,min,max,var,count" << std::endl;
+
+        std::array<Accumulator, c_maxRankValue+1> accumulators;
+
+        for (auto shardId = 0; shardId < ingestor.GetShardCount(); ++shardId)
         {
+            IShard& shard = ingestor.GetShard(shardId);
+
+            // Write out each document's raw column data per shard.
             // No need to use CsvTableFormatter for escaping because all values
             // are numbers.
-            auto out = outFileManager->ColumnDensities().OpenForWrite();
+            auto out = outFileManager->ColumnDensities(shardId).OpenForWrite();
             Column::WriteHeader(*out);
-            for (auto column : columns)
+
+            size_t docNumber = 0;
+            while (shard.FindNextActive(docNumber))
             {
-                column.Write(*out);
-            }
-        }
+                const DocumentHandleInternal 
+                    handle(shard.GetHandle(docNumber++));
+                const DocId docId = handle.GetDocId();
+                Slice const & slice = handle.GetSlice();
 
+                // TODO: handle.GetPostingCount() instead of 0
+                Column column(docId, shardId, 0);
 
-        //
-        // Generate summary.
-        //
-        {
-            auto out = outFileManager->ColumnDensitySummary().OpenForWrite();
+                void const * buffer = slice.GetSliceBuffer();
+                const DocIndex docIndex = handle.GetIndex();
 
-            *out << "Summary" << std::endl;
-
-            for (Rank rank = 0; rank <= c_maxRankValue; ++rank)
-            {
-                Accumulator accumulator;
-                for (auto column : columns)
+                for (Rank rank = 0; rank <= c_maxRankValue; ++rank)
                 {
-                    accumulator.Record(column.m_densities[rank]);
+                    RowTableDescriptor rowTable = slice.GetRowTable(rank);
+
+                    size_t bitCount = 0;
+                    const size_t rowCount = rowTable.GetRowCount();
+                    for (RowIndex row = 0; row < rowCount; ++row)
+                    {
+                        if (rowTable.GetBit(buffer, row, docIndex) != 0)
+                        {
+                            ++bitCount;
+                        }
+                    }
+
+                    column.SetCount(rank, bitCount);
+
+                    double density =
+                        (rowCount == 0) ? 0.0 : static_cast<double>(bitCount) / rowCount;
+                    column.SetDensity(rank, density);
+                    accumulators[rank].Record(density);
                 }
 
-                *out << "Rank " << rank << std::endl
-                    << "  column density: " << std::endl
-                    << "      min: " << accumulator.GetMin() << std::endl
-                    << "      max: " << accumulator.GetMax() << std::endl
-                    << "     mean: " << accumulator.GetMean() << std::endl
-                    << "      var: " << accumulator.GetVariance() << std::endl
-                    << "    count: " << accumulator.GetCount() << std::endl;
+                column.Write(*out);
+            }
+
+            //
+            // Generate document summary by rank for shard
+            //
+            for (Rank rank = 0; rank < c_maxRankValue; ++rank)
+            {
+                Accumulator accumulator = accumulators[rank];
+                if (accumulator.GetCount() == 0)
+                    continue;
+
+                *summaryOut
+                    << shardId << ","
+                    << rank << ","
+                    << accumulator.GetMean() << ","
+                    << accumulator.GetMin() << ","
+                    << accumulator.GetMax() << ","
+                    << accumulator.GetVariance() << ","
+                    << accumulator.GetCount() << std::endl;
+
+                accumulators[rank].Reset();
             }
         }
-
     }
 
 

--- a/src/Index/src/RowTableAnalyzer.h
+++ b/src/Index/src/RowTableAnalyzer.h
@@ -48,7 +48,13 @@ namespace BitFunnel
         void AnalyzeRowsInOneShard(
             ShardId const & shardId,
             ITermToText const & termToText,
-            std::ostream& out) const;
+            std::ostream& out,
+            std::ostream& summaryOut) const;
+        void WriteRowSummary(
+            ShardId const & shardId,
+            Term::IdfX10 idfX10,
+            std::ostream& summaryOut,
+            std::array<Accumulator, c_maxRankValue>* accumulators) const;
 
 
         class Column

--- a/src/Index/src/Shard.cpp
+++ b/src/Index/src/Shard.cpp
@@ -511,6 +511,51 @@ namespace BitFunnel
     }
 
 
+    DocumentHandle Shard::GetHandle(size_t docNumber) const
+    {
+        // Hold a token to ensure that m_sliceBuffers won't be recycled.
+        auto token = m_tokenManager.RequestToken();
+
+        size_t sliceIndex = docNumber / GetSliceCapacity();
+        size_t docSliceIndex = docNumber % GetSliceCapacity();
+
+        if (sliceIndex < (*m_sliceBuffers).size())
+        {
+            Slice* slice = Slice::GetSliceFromBuffer((*m_sliceBuffers)[sliceIndex],
+                                                      GetSlicePtrOffset());
+            return DocumentHandleInternal::DocumentHandleInternal(slice, docSliceIndex);
+        }
+        else
+        {
+            throw RecoverableError("Invalid document number");
+        }
+    }
+
+
+    bool Shard::FindNextActive(size_t& docNumber) const
+    {
+        // Hold a token to ensure that m_sliceBuffers won't be recycled.
+        auto token = m_tokenManager.RequestToken();
+
+        try
+        {
+            while (1)
+            {
+                DocumentHandleInternal handle = GetHandle(docNumber);
+                if (handle.IsActive())
+                {
+                    return true;
+                }
+                ++docNumber;
+            }
+        }
+        catch (RecoverableError e)
+        {
+            return false;
+        }
+    }
+
+
     std::vector<double> Shard::GetDensities(Rank rank) const
     {
         // Hold a token to ensure that m_sliceBuffers won't be recycled.

--- a/src/Index/src/Shard.h
+++ b/src/Index/src/Shard.h
@@ -115,6 +115,21 @@ namespace BitFunnel
         virtual void TemporaryWriteAllSlices(IFileManager& fileManager) const override;
 
 
+        // Get the document handle for the nth document in a shard
+        // Warning: this method may not be thread-safe.
+        // If the document's slice is recycled, the returned handle
+        // could point to a different document than intended.
+        virtual DocumentHandle GetHandle(size_t docNumber) const override;
+
+        // Find next active document in shard, looking first at docNumber
+        // - Return true if found and modify docNumber to position of active document
+        // - Return false if no more active documents
+        // Warning: this method may not be thread-safe.
+        // If the document's slice is recycled, the altered docNumber
+        // may no longer be valid or could reference a different document than intended.
+        virtual bool FindNextActive(size_t& docNumber) const override;
+
+
         // Returns an std::vector containing the bit densities for each row in
         // the RowTable with the specified rank. Bit densities are computed
         // over all slices, for those columns that correspond to active

--- a/src/Index/src/TermToText.cpp
+++ b/src/Index/src/TermToText.cpp
@@ -33,6 +33,9 @@ namespace BitFunnel
     }
 
 
+    const std::string TermToText::m_emptyString;
+
+
     TermToText::TermToText()
     {
     }

--- a/src/Index/src/TermToText.h
+++ b/src/Index/src/TermToText.h
@@ -75,7 +75,7 @@ namespace BitFunnel
     private:
         // Empty string returned by Lookup() when hash is not in the map.
         // Implemented as a member because Lookup() returns a const reference.
-        const std::string m_emptyString;
+        static const std::string m_emptyString;
 
         // Term::Hash ==> std::string map.
         std::unordered_map<Term::Hash, std::string> m_termToText;

--- a/src/Index/src/TreatmentOptimal.cpp
+++ b/src/Index/src/TreatmentOptimal.cpp
@@ -107,7 +107,6 @@ namespace BitFunnel
                       bitsPerDocument);
         }
 
-        std::cout << "Best configuration is " << m_bestConfiguration << std::endl;
         return m_bestConfiguration;
     }
 
@@ -295,6 +294,15 @@ namespace BitFunnel
                                              Term::c_maxIdfX10Value + 1);
 
         distributor->WaitForCompletion();
+
+        for (Term::IdfX10 idf = 0; idf <= Term::c_maxIdfX10Value; ++idf)
+        {
+            std::cout
+                << static_cast<uint32_t>(idf)
+                << ": best configuration is "
+                << m_configurations[idf].ConfigurationAsDecimalDigits()
+                << std::endl;
+        }
     }
 
 

--- a/tools/BitFunnel/src/REPL.cpp
+++ b/tools/BitFunnel/src/REPL.cpp
@@ -273,6 +273,14 @@ namespace BitFunnel
                     throw e;
                 }
             }
+            catch (Logging::CheckException e)
+            {
+                output << "Error: " << e.GetMessage() << std::endl;
+                if (environment.GetFailOnException())
+                {
+                    throw e;
+                }
+            }
         }
         taskPool.Shutdown();
     }


### PR DESCRIPTION
`analyze` now generates four kinds of output:

* RowDensity-#.csv files showing (by shard) all terms and their densities by rank
* RowDensitySummary.csv file showing summary density statistics by shard, idfx10, and rank
* ColumnDensity-#.csv files showing (by shard) all ingested documents and their densities by rank
* ColumnDensitySummary.csv showing summary density statistics by shard and rank

In addition:

* Shard supports iteration through all documents in a shard, replacing the MaxDocId capability
* `show rows` and `analyze` use the new document iteration capability
* `termtable` term treatment output is now complete, labeled and de-threaded