### PR TITLE
Enable ResultsBuffer iterator to be usable

### DIFF
--- a/src/Plan/src/ResultsBuffer.h
+++ b/src/Plan/src/ResultsBuffer.h
@@ -38,6 +38,8 @@ namespace BitFunnel
     class ResultsBuffer
     {
     public:
+		class const_iterator;
+
         class Result
         {
         public:
@@ -87,35 +89,6 @@ namespace BitFunnel
             m_size++;
         }
 
-        class const_iterator
-            : public std::iterator<std::input_iterator_tag, Result>
-        {
-        public:
-            const_iterator(Result * result)
-                : m_current(result)
-            {
-            }
-
-            bool operator!=(const_iterator const & other) const
-            {
-                return m_current != other.m_current;
-            }
-
-            const_iterator& operator++()
-            {
-                m_current++;
-                return *this;
-            }
-
-            Result const operator*() const
-            {
-                return *m_current;
-            }
-
-        private:
-            Result const * m_current;
-        };
-
         const_iterator begin() const
         {
             return const_iterator(m_buffer);
@@ -135,7 +108,37 @@ namespace BitFunnel
         size_t m_capacity;
         size_t m_size;
         Result * m_buffer;
-    };
+
+		class const_iterator
+			: public std::iterator<std::input_iterator_tag, Result>
+		{
+		public:
+			const_iterator(Result * result)
+				: m_current(result)
+			{
+			}
+
+			bool operator!=(const_iterator const & other) const
+			{
+				return m_current != other.m_current;
+			}
+
+			const_iterator& operator++()
+			{
+				m_current++;
+				return *this;
+			}
+
+			Result const operator*() const
+			{
+				return *m_current;
+			}
+
+		private:
+			Result const * m_current;
+		};
+
+	};
     static_assert(std::is_standard_layout<ResultsBuffer>::value,
                   "Generated code requires standard layout for ResultsBuffer.");
 }


### PR DESCRIPTION
When trying to iterate over a ResultsBuffer, the VS compiler would not let me declare or create the const_iterator. Furthermore, Intellisense would not show or let me use the ->begin() method.

As best as I can determine, injecting a nested class at the wrong place inside a class causes both tools to hide aspects of the class definition to itself. I am really not sure of the thinking behind this.

The attached commit allows me to create and use the iterator, though Intellisense is still confused by what methods are available to a pointer to Result (perhaps it too needs to be moved?)