### PR TITLE
Make BitFunnel's full query capability accessible using only /inc headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(MOCKS_HFILES
 set(PLAN_HFILES
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/Factories.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/IMatchVerifier.h
+  ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/IQueryEngine.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryInstrumentation.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryParser.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryRunner.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ set(PLAN_HFILES
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryInstrumentation.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryParser.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/QueryRunner.h
+  ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/ResultsBuffer.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/TermMatchNode.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/VerifyOneQuery.h
   ${CMAKE_SOURCE_DIR}/inc/BitFunnel/Plan/VerifyOneQuerySynthetic.h

--- a/inc/BitFunnel/Plan/IQueryEngine.h
+++ b/inc/BitFunnel/Plan/IQueryEngine.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2016, Microsoft
+// Copyright (c) 2018, Microsoft
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,44 +22,42 @@
 
 #pragma once
 
-#include <memory>  // std::unique_ptr return value.
-#include <string>
-#include <vector>  // std::vector return value.
-
-#include "BitFunnel/BitFunnelTypes.h"  // DocId.
+#include "BitFunnel/IInterface.h"       // Base class.
 
 
 namespace BitFunnel
 {
-    class IAllocator;
-    class IDiagnosticStream;
-    class IInputStream;
-    class IMatchVerifier;
-    class IQueryEngine;
-    class IPlanRows;
-    class IRowSet;
-    class ISimpleIndex;
-    class IStreamConfiguration;
     class QueryInstrumentation;
     class ResultsBuffer;
-    class SimpleResultsProcessor;
     class TermMatchNode;
 
-    namespace Factories
+    //*************************************************************************
+    //
+    // IQueryEngine
+    //
+    // An abstract base class or interface for concrete QueryEngine classes,
+    // such as thuse that use NativeJIT or interpret the query tree.
+    // It defines the common public methods needed to run parsed queries.
+    //
+    //*************************************************************************
+    class IQueryEngine : public IInterface
     {
-        std::unique_ptr<IQueryEngine> CreateQueryEngine(ISimpleIndex const & index,
-                                                                   IStreamConfiguration const & config);
+    public:
+        // Parse a query
+        virtual TermMatchNode const *Parse(const char *query) = 0;
 
-        std::unique_ptr<IMatchVerifier> CreateMatchVerifier(std::string query);
+        // Runs a parsed query
+        virtual void Run(TermMatchNode const * tree,
+                         QueryInstrumentation & instrumentation,
+                         ResultsBuffer & resultsBuffer) = 0;
 
-        IPlanRows& CreatePlanRows(IInputStream& input,
-                                  const ISimpleIndex& index,
-                                  IAllocator& allocator);
+        // Adds the diagnostic keyword prefix to the list of prefixes that
+        // enable diagnostics.
+        virtual void EnableDiagnostic(char const * prefix) = 0;
 
-        std::unique_ptr<SimpleResultsProcessor> CreateSimpleResultsProcessor();
+        // Removes the diagnostic keyword prefix from the list of prefixes
+        // that enable diagnostics.
+        virtual void DisableDiagnostic(char const * prefix) = 0;
 
-        IRowSet& CreateRowSet(ISimpleIndex const & indexData,
-                              IPlanRows const & planRows,
-                              IAllocator& allocator);
-    }
+    };
 }

--- a/inc/BitFunnel/Plan/QueryInstrumentation.h
+++ b/inc/BitFunnel/Plan/QueryInstrumentation.h
@@ -40,7 +40,7 @@ namespace BitFunnel
     public:
         class Data;
 
-        inline void QuerySuceeded()
+        inline void QuerySucceeded()
         {
             m_data.m_succeeded = true;
         }

--- a/inc/BitFunnel/Plan/ResultsBuffer.h
+++ b/inc/BitFunnel/Plan/ResultsBuffer.h
@@ -38,6 +38,8 @@ namespace BitFunnel
     class ResultsBuffer
     {
     public:
+		class const_iterator;
+
         class Result
         {
         public:
@@ -87,35 +89,6 @@ namespace BitFunnel
             m_size++;
         }
 
-        class const_iterator
-            : public std::iterator<std::input_iterator_tag, Result>
-        {
-        public:
-            const_iterator(Result * result)
-                : m_current(result)
-            {
-            }
-
-            bool operator!=(const_iterator const & other) const
-            {
-                return m_current != other.m_current;
-            }
-
-            const_iterator& operator++()
-            {
-                m_current++;
-                return *this;
-            }
-
-            Result const operator*() const
-            {
-                return *m_current;
-            }
-
-        private:
-            Result const * m_current;
-        };
-
         const_iterator begin() const
         {
             return const_iterator(m_buffer);
@@ -135,7 +108,37 @@ namespace BitFunnel
         size_t m_capacity;
         size_t m_size;
         Result * m_buffer;
-    };
+
+		class const_iterator
+			: public std::iterator<std::input_iterator_tag, Result>
+		{
+		public:
+			const_iterator(Result * result)
+				: m_current(result)
+			{
+			}
+
+			bool operator!=(const_iterator const & other) const
+			{
+				return m_current != other.m_current;
+			}
+
+			const_iterator& operator++()
+			{
+				m_current++;
+				return *this;
+			}
+
+			Result const operator*() const
+			{
+				return *m_current;
+			}
+
+		private:
+			Result const * m_current;
+		};
+
+	};
     static_assert(std::is_standard_layout<ResultsBuffer>::value,
                   "Generated code requires standard layout for ResultsBuffer.");
 }

--- a/src/Plan/src/ByteCodeInterpreter.cpp
+++ b/src/Plan/src/ByteCodeInterpreter.cpp
@@ -67,7 +67,7 @@ Decide on type of Slices
         ptrdiff_t const * rowOffsets,
         IDiagnosticStream * diagnosticStream,
         QueryInstrumentation & instrumentation,
-        CacheLineRecorder * cacheLineRecorder)
+        size_t sliceBufferSize)
       : m_code(code.GetCode()),
         m_jumpTable(code.GetJumpTable()),
         m_resultsBuffer(resultsBuffer),
@@ -78,11 +78,19 @@ Decide on type of Slices
         m_rowOffsets(rowOffsets),
         m_dedupe(),
         m_diagnosticStream(diagnosticStream),
-        m_instrumentation(instrumentation),
-        m_cacheLineRecorder(cacheLineRecorder)
+        m_instrumentation(instrumentation)
     {
+        m_cacheLineRecorder = sliceBufferSize ? new CacheLineRecorder(sliceBufferSize) : nullptr;
     }
 
+
+    ByteCodeInterpreter::~ByteCodeInterpreter()
+    {
+        if (m_cacheLineRecorder != nullptr)
+        {
+            delete m_cacheLineRecorder;
+        }
+    }
 
     bool ByteCodeInterpreter::Run()
     {

--- a/src/Plan/src/ByteCodeInterpreter.cpp
+++ b/src/Plan/src/ByteCodeInterpreter.cpp
@@ -31,9 +31,9 @@
 #include "BitFunnel/Index/DocumentHandle.h"
 #include "BitFunnel/Index/Factories.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "ByteCodeInterpreter.h"
 #include "CacheLineRecorder.h"
-#include "ResultsBuffer.h"
 
 
 namespace BitFunnel

--- a/src/Plan/src/ByteCodeInterpreter.h
+++ b/src/Plan/src/ByteCodeInterpreter.h
@@ -72,8 +72,10 @@ namespace BitFunnel
                             ptrdiff_t const * rowOffsets,
                             IDiagnosticStream * diagnosticStream,
                             QueryInstrumentation & instrumentation,
-                            CacheLineRecorder * cacheLineRecorder);
+                            size_t sliceBufferSize);
 
+        ~ByteCodeInterpreter();
+        
         // Runs the instruction sequence for a specified number of iterations.
         // Each iteration processes a single quadword of row data at the
         // highest rank in the plan.  Returns true to indicate early

--- a/src/Plan/src/ByteCodeQueryEngine.cpp
+++ b/src/Plan/src/ByteCodeQueryEngine.cpp
@@ -1,0 +1,135 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2018, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <iostream>
+
+#include "BitFunnel/Configuration/Factories.h"
+#include "BitFunnel/Plan/Factories.h"
+#include "BitFunnel/Index/IIngestor.h"
+#include "BitFunnel/Index/IShard.h"
+#include "BitFunnel/Index/Token.h"
+#include "BitFunnel/Plan/QueryInstrumentation.h"
+#include "BitFunnel/Plan/QueryParser.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
+#include "BitFunnel/Utilities/Allocator.h"
+#include "BitFunnel/Utilities/Factories.h"
+#include "ByteCodeQueryEngine.h"
+#include "CompileNode.h"
+#include "QueryPlanner.h"
+#include "RowSet.h"
+
+
+namespace BitFunnel
+{
+    ByteCodeQueryEngine::ByteCodeQueryEngine(ISimpleIndex const & index,
+                                             IStreamConfiguration const & config,
+                                             size_t treeAllocatorBytes)
+        : m_index(index),
+          m_config(config),
+          m_diagnostic(Factories::CreateDiagnosticStream(std::cout)),
+          m_matchTreeAllocator(new BitFunnel::Allocator(treeAllocatorBytes))
+    {
+    }
+
+    // Parse a query
+    TermMatchNode const *ByteCodeQueryEngine::Parse(const char *query)
+    {
+        m_matchTreeAllocator->Reset();
+        QueryParser parser(query,
+            m_config,
+            *m_matchTreeAllocator);
+        return parser.Parse();
+    }
+
+    // Runs a parsed query
+    void ByteCodeQueryEngine::Run(TermMatchNode const * tree,
+        QueryInstrumentation & instrumentation,
+        ResultsBuffer & resultsBuffer)
+    {
+        const int c_arbitraryRowCount = 500;
+        QueryPlanner planner(*tree,
+                             c_arbitraryRowCount,
+                             m_index,
+                             *m_matchTreeAllocator,
+                             *m_diagnostic,
+                             instrumentation);
+        CompileNode const & compileTree = planner.GetCompileTree();
+        const Rank initialRank = planner.GetInitialRank();
+        const RowSet & rowSet = planner.GetRowSet();
+
+        // TODO: Clear results buffer here?
+        compileTree.Compile(m_code);
+        m_code.Seal();
+
+        instrumentation.FinishPlanning();
+        resultsBuffer.Reset();
+
+        // Get token before we GetSliceBuffers.
+        {
+            auto token = m_index.GetIngestor().GetTokenManager().RequestToken();
+
+            for (ShardId shardId = 0; shardId < m_index.GetIngestor().GetShardCount(); ++shardId)
+            {
+                auto & shard = m_index.GetIngestor().GetShard(shardId);
+                auto & sliceBuffers = shard.GetSliceBuffers();
+
+                // Iterations per slice calculation.
+                auto iterationsPerSlice = shard.GetSliceCapacity() >> 6 >> initialRank;
+
+                auto countCacheLines = m_diagnostic->IsEnabled("planning/countcachelines");
+
+                ByteCodeInterpreter interpreter(m_code,
+                    resultsBuffer,
+                    sliceBuffers.size(),
+                    sliceBuffers.data(),
+                    iterationsPerSlice,
+                    initialRank,
+                    rowSet.GetRowOffsets(shardId),
+                    nullptr,
+                    instrumentation,
+                    countCacheLines ? shard.GetSliceBufferSize() : 0);
+
+                interpreter.Run();
+            }
+
+            instrumentation.FinishMatching();
+            instrumentation.SetMatchCount(resultsBuffer.size());
+            instrumentation.QuerySucceeded();
+        } // End of token lifetime.
+    }
+
+
+    // Adds the diagnostic keyword prefix to the list of prefixes that
+    // enable diagnostics.
+    void ByteCodeQueryEngine::EnableDiagnostic(char const * prefix)
+    {
+        m_diagnostic->Enable(prefix);
+    }
+
+    // Removes the diagnostic keyword prefix from the list of prefixes
+    // that enable diagnostics.
+    void ByteCodeQueryEngine::DisableDiagnostic(char const * prefix)
+    {
+        m_diagnostic->Disable(prefix);
+    }
+
+}

--- a/src/Plan/src/ByteCodeQueryEngine.h
+++ b/src/Plan/src/ByteCodeQueryEngine.h
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2018, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <memory>                                   // std::unique_ptr embedded.
+
+#include "BitFunnel/Configuration/IStreamConfiguration.h"
+#include "BitFunnel/Index/ISimpleIndex.h"
+#include "BitFunnel/IDiagnosticStream.h"
+#include "BitFunnel/Plan/IQueryEngine.h"
+#include "ByteCodeInterpreter.h"
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // ByteCodeQueryEngine
+    //
+    // The class used to run parsed queries using the ByteCodeInterpreter.
+    //
+    //*************************************************************************
+    class ByteCodeQueryEngine : public IQueryEngine
+    {
+    public:
+        ByteCodeQueryEngine(ISimpleIndex const & index,
+                            IStreamConfiguration const & config,
+                            size_t treeAllocatorBytes);
+
+        // Parse a query
+        virtual TermMatchNode const *Parse(const char *query) override;
+
+        // Runs a parsed query
+        virtual void Run(TermMatchNode const * tree,
+                         QueryInstrumentation & instrumentation,
+                         ResultsBuffer & resultsBuffer) override;
+
+        // Adds the diagnostic keyword prefix to the list of prefixes that
+        // enable diagnostics.
+        virtual void EnableDiagnostic(char const * prefix) override;
+
+        // Removes the diagnostic keyword prefix from the list of prefixes
+        // that enable diagnostics.
+        virtual void DisableDiagnostic(char const * prefix) override;
+
+    private:
+        ISimpleIndex const & m_index;
+        IStreamConfiguration const & m_config;
+        std::unique_ptr<IDiagnosticStream> m_diagnostic;
+        std::unique_ptr<IAllocator> m_matchTreeAllocator;
+
+        ByteCodeGenerator m_code;
+    };
+}

--- a/src/Plan/src/CMakeLists.txt
+++ b/src/Plan/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CPPFILES
     AbstractRow.cpp
     AbstractRowEnumerator.cpp
     ByteCodeInterpreter.cpp
+    ByteCodeQueryEngine.cpp
     CacheLineRecorder.cpp
     CompileNode.cpp
     MachineCodeGenerator.cpp
@@ -11,11 +12,11 @@ set(CPPFILES
     MatchTreeRewriter.cpp
     MatchVerifier.cpp
     NativeCodeGenerator.cpp
+    NativeJITQueryEngine.cpp
     PlanRows.cpp
     QueryInstrumentation.cpp
     QueryParser.cpp
     QueryPlanner.cpp
-    QueryResources.cpp
     QueryRunner.cpp
     RankDownCompiler.cpp
     RankZeroCompiler.cpp
@@ -42,6 +43,7 @@ set(POSIX_CPPFILES
 set(PRIVATE_HFILES
     AbstractRow.h
     ByteCodeInterpreter.h
+    ByteCodeQueryEngine.h
     CacheLineRecorder.h
     CompileNode.h
     ICodeGenerator.h
@@ -52,8 +54,8 @@ set(PRIVATE_HFILES
     MatchTreeRewriter.h
     MatchVerifier.h
     NativeCodeGenerator.h
+    NativeJITQueryEngine.h
     QueryPlanner.h
-    QueryResources.h
     RowMatchNode.h
     RowSet.h
     RankDownCompiler.h

--- a/src/Plan/src/CMakeLists.txt
+++ b/src/Plan/src/CMakeLists.txt
@@ -54,7 +54,6 @@ set(PRIVATE_HFILES
     NativeCodeGenerator.h
     QueryPlanner.h
     QueryResources.h
-    ResultsBuffer.h
     RowMatchNode.h
     RowSet.h
     RankDownCompiler.h

--- a/src/Plan/src/MatchTreeCompiler.cpp
+++ b/src/Plan/src/MatchTreeCompiler.cpp
@@ -23,7 +23,6 @@
 
 #include "BitFunnel/Utilities/Allocator.h"
 #include "MatchTreeCompiler.h"
-#include "QueryResources.h"
 
 using namespace NativeJIT;
 
@@ -35,13 +34,14 @@ namespace BitFunnel
     // MatchTreeCompiler
     //
     //*************************************************************************
-    MatchTreeCompiler::MatchTreeCompiler(QueryResources & resources,
+    MatchTreeCompiler::MatchTreeCompiler(Allocators::IAllocator & expressionTreeAllocator,
+                                         NativeJIT::FunctionBuffer & code,
                                          CompileNode const & tree,
                                          RegisterAllocator const & registers,
                                          Rank initialRank)
     {
-        NativeCodeGenerator::Prototype expression(resources.GetExpressionTreeAllocator(),
-                                                  resources.GetCode());
+        NativeCodeGenerator::Prototype expression(expressionTreeAllocator,
+                                                  code);
         // TODO: Remove temporary debugging output.
         //expression.EnableDiagnostics(std::cout);
 

--- a/src/Plan/src/MatchTreeCompiler.h
+++ b/src/Plan/src/MatchTreeCompiler.h
@@ -39,7 +39,6 @@ namespace NativeJIT
 namespace BitFunnel
 {
     class CompileNode;
-    class QueryResources;
     class RegisterAllocator;
     class ResultsBuffer;
 
@@ -51,7 +50,8 @@ namespace BitFunnel
     class MatchTreeCompiler
     {
     public:
-        MatchTreeCompiler(QueryResources & resources,
+        MatchTreeCompiler(Allocators::IAllocator & resources,
+                          NativeJIT::FunctionBuffer & code,
                           CompileNode const & tree,
                           RegisterAllocator const & registers,
                           Rank initialRank);

--- a/src/Plan/src/NativeCodeGenerator.h
+++ b/src/Plan/src/NativeCodeGenerator.h
@@ -25,9 +25,9 @@
 #include <stddef.h>     // size_t, ptrdiff_t parameters.
 
 #include "BitFunnel/BitFunnelTypes.h"           // Rank parameter.
+#include "BitFunnel/Plan/ResultsBuffer.h"       // ResultsBuffer::Result type.
 #include "NativeJIT/CodeGen/FunctionBuffer.h"   // FunctionBuffer embedded.
 #include "NativeJIT/Function.h"                 // Function in typedef.
-#include "ResultsBuffer.h"                      // ResultsBuffer::Result type.
 
 
 namespace NativeJIT

--- a/src/Plan/src/NativeJITQueryEngine.cpp
+++ b/src/Plan/src/NativeJITQueryEngine.cpp
@@ -1,0 +1,159 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2018, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <iostream>
+
+#include "BitFunnel/Configuration/Factories.h"
+#include "BitFunnel/Plan/Factories.h"
+#include "BitFunnel/Index/IIngestor.h"
+#include "BitFunnel/Index/IShard.h"
+#include "BitFunnel/Index/Token.h"
+#include "BitFunnel/Plan/QueryInstrumentation.h"
+#include "BitFunnel/Plan/QueryParser.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
+#include "BitFunnel/Utilities/Allocator.h"
+#include "BitFunnel/Utilities/Factories.h"
+#include "NativeJITQueryEngine.h"
+#include "CompileNode.h"
+#include "MatchTreeCompiler.h"
+#include "NativeCodeGenerator.h"
+#include "QueryPlanner.h"
+#include "RegisterAllocator.h"
+#include "RowSet.h"
+
+
+namespace BitFunnel
+{
+    std::unique_ptr<IQueryEngine> Factories::CreateQueryEngine(ISimpleIndex const & index,
+                                                               IStreamConfiguration const & config)
+    {
+        const size_t c_allocatorSize = 1ull << 17;
+        return std::make_unique<NativeJITQueryEngine>(index, config, c_allocatorSize, c_allocatorSize);
+    }
+
+    NativeJITQueryEngine::NativeJITQueryEngine(ISimpleIndex const & index,
+                                               IStreamConfiguration const & config,
+                                               size_t treeAllocatorBytes,
+                                               size_t codeAllocatorBytes)
+        : m_index(index),
+          m_config(config),
+          m_diagnostic(Factories::CreateDiagnosticStream(std::cout)),
+          m_matchTreeAllocator(new BitFunnel::Allocator(treeAllocatorBytes)),
+          m_expressionTreeAllocator(new NativeJIT::Allocator(treeAllocatorBytes)),
+          m_codeAllocator(new NativeJIT::ExecutionBuffer(codeAllocatorBytes))
+    {
+        m_code.reset(new NativeJIT::FunctionBuffer(*m_codeAllocator,
+                                                   static_cast<unsigned>(codeAllocatorBytes)));
+    }
+
+    // Parse a query
+    TermMatchNode const *NativeJITQueryEngine::Parse(const char *query)
+    {
+        m_matchTreeAllocator->Reset();
+        m_expressionTreeAllocator->Reset();
+        // WARNING: Do not reset m_codeAllocator. It is used to provision m_code.
+        m_code->Reset();
+
+        QueryParser parser(query,
+            m_config,
+            *m_matchTreeAllocator);
+        return parser.Parse();
+    }
+
+    // Runs a parsed query
+    void NativeJITQueryEngine::Run(TermMatchNode const * tree,
+        QueryInstrumentation & instrumentation,
+        ResultsBuffer & resultsBuffer)
+    {
+        const int c_arbitraryRowCount = 500;
+        QueryPlanner planner(*tree,
+                             c_arbitraryRowCount,
+                             m_index,
+                             *m_matchTreeAllocator,
+                             *m_diagnostic,
+                             instrumentation);
+        CompileNode const & compileTree = planner.GetCompileTree();
+        const Rank initialRank = planner.GetInitialRank();
+        const RowSet & rowSet = planner.GetRowSet();
+
+        // Perform register allocation on the compile tree.
+        RegisterAllocator const registers(compileTree,
+                                          rowSet.GetRowCount(),
+                                          c_registerBase,
+                                          c_registerCount,
+                                          *m_matchTreeAllocator);
+
+        MatchTreeCompiler compiler(*m_expressionTreeAllocator,
+                                   *m_code,
+                                   compileTree,
+                                   registers,
+                                   initialRank);
+
+
+        instrumentation.FinishPlanning();
+
+        resultsBuffer.Reset();
+
+        // Get token before we GetSliceBuffers.
+        {
+            auto token = m_index.GetIngestor().GetTokenManager().RequestToken();
+
+            for (ShardId shardId = 0; shardId < m_index.GetIngestor().GetShardCount(); ++shardId)
+            {
+                auto & shard = m_index.GetIngestor().GetShard(shardId);
+                auto & sliceBuffers = shard.GetSliceBuffers();
+
+                // Iterations per slice calculation.
+                auto iterationsPerSlice = shard.GetSliceCapacity() >> 6 >> initialRank;
+
+
+                size_t quadwordCount = compiler.Run(sliceBuffers.size(),
+                    sliceBuffers.data(),
+                    iterationsPerSlice,
+                    rowSet.GetRowOffsets(shardId),
+                    resultsBuffer);
+
+                instrumentation.IncrementQuadwordCount(quadwordCount);
+            }
+
+            instrumentation.FinishMatching();
+            instrumentation.SetMatchCount(resultsBuffer.size());
+            instrumentation.QuerySucceeded();
+        } // End of token lifetime.
+    }
+
+
+    // Adds the diagnostic keyword prefix to the list of prefixes that
+    // enable diagnostics.
+    void NativeJITQueryEngine::EnableDiagnostic(char const * prefix)
+    {
+        m_diagnostic->Enable(prefix);
+    }
+
+    // Removes the diagnostic keyword prefix from the list of prefixes
+    // that enable diagnostics.
+    void NativeJITQueryEngine::DisableDiagnostic(char const * prefix)
+    {
+        m_diagnostic->Disable(prefix);
+    }
+
+}

--- a/src/Plan/src/NativeJITQueryEngine.h
+++ b/src/Plan/src/NativeJITQueryEngine.h
@@ -1,0 +1,86 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2018, Microsoft
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <memory>                                   // std::unique_ptr embedded.
+
+#include "BitFunnel/Configuration/IStreamConfiguration.h"
+#include "BitFunnel/Index/ISimpleIndex.h"
+#include "BitFunnel/IDiagnosticStream.h"
+#include "BitFunnel/Plan/IQueryEngine.h"
+#include "NativeJIT/CodeGen/ExecutionBuffer.h"  // Template parameter.
+#include "NativeJIT/CodeGen/FunctionBuffer.h"   // Template parameter.
+#include "Temporary/Allocator.h"                // Template parameter.
+
+
+namespace BitFunnel
+{
+    //*************************************************************************
+    //
+    // ByteCodeQueryEngine
+    //
+    // The class used to run parsed queries using the ByteCodeInterpreter.
+    //
+    //*************************************************************************
+    class NativeJITQueryEngine : public IQueryEngine
+    {
+    public:
+        NativeJITQueryEngine(ISimpleIndex const & index,
+                             IStreamConfiguration const & config,
+                             size_t treeAllocatorBytes,
+                             size_t codeAllocatorBytes);
+
+        // Parse a query
+        virtual TermMatchNode const *Parse(const char *query) override;
+
+        // Runs a parsed query
+        virtual void Run(TermMatchNode const * tree,
+                         QueryInstrumentation & instrumentation,
+                         ResultsBuffer & resultsBuffer) override;
+
+        // Adds the diagnostic keyword prefix to the list of prefixes that
+        // enable diagnostics.
+        virtual void EnableDiagnostic(char const * prefix) override;
+
+        // Removes the diagnostic keyword prefix from the list of prefixes
+        // that enable diagnostics.
+        virtual void DisableDiagnostic(char const * prefix) override;
+
+    private:
+        ISimpleIndex const & m_index;
+        IStreamConfiguration const & m_config;
+        std::unique_ptr<IDiagnosticStream> m_diagnostic;
+        std::unique_ptr<IAllocator> m_matchTreeAllocator;
+        std::unique_ptr<NativeJIT::Allocator> m_expressionTreeAllocator;
+        std::unique_ptr<NativeJIT::ExecutionBuffer> m_codeAllocator;
+        std::unique_ptr<NativeJIT::FunctionBuffer> m_code;
+
+        // First available row pointer register is R8.
+        // TODO: is this valid on all platforms or only on Windows?
+        static const unsigned c_registerBase = 8;
+
+        // Row pointers stored in the eight registers R8..R15.
+        // TODO: is this valid on all platforms or only on Windows?
+        static const unsigned c_registerCount = 8;
+    };
+}

--- a/src/Plan/src/QueryPlanner.cpp
+++ b/src/Plan/src/QueryPlanner.cpp
@@ -247,7 +247,7 @@ namespace BitFunnel
                                                rowSet.GetRowOffsets(shardId),
                                                nullptr,
                                                instrumentation,
-                                               resources.GetCacheLineRecorder());
+                                               resources.GetCountCacheLines()? shard.GetSliceBufferSize() : 0);
 
                 intepreter.Run();
             }

--- a/src/Plan/src/QueryPlanner.cpp
+++ b/src/Plan/src/QueryPlanner.cpp
@@ -31,15 +31,11 @@
 #include "BitFunnel/Plan/TermMatchNode.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "BitFunnel/Utilities/IObjectFormatter.h"
-#include "ByteCodeInterpreter.h"
 #include "CompileNode.h"
 #include "IPlanRows.h"
-#include "MatchTreeCompiler.h"
 #include "MatchTreeRewriter.h"
 #include "QueryPlanner.h"
-#include "QueryResources.h"
 #include "RankDownCompiler.h"
-#include "RegisterAllocator.h"
 #include "RowSet.h"
 #include "TermPlan.h"
 #include "TermPlanConverter.h"
@@ -47,27 +43,6 @@
 
 namespace BitFunnel
 {
-    // TODO: remove. This is a quick shortcut to try to connect QueryPlanner the
-    // way SimplePlanner is connected.
-    void Factories::RunQueryPlanner(TermMatchNode const & tree,
-                                    ISimpleIndex const & index,
-                                    QueryResources & resources,
-                                    IDiagnosticStream & diagnosticStream,
-                                    QueryInstrumentation & instrumentation,
-                                    ResultsBuffer & resultsBuffer,
-                                    bool useNativeCode)
-    {
-        const int c_arbitraryRowCount = 500;
-        QueryPlanner planner(tree,
-                             c_arbitraryRowCount,
-                             index,
-                             resources,
-                             diagnosticStream,
-                             instrumentation,
-                             resultsBuffer,
-                             useNativeCode);
-    }
-
 
     unsigned const c_targetCrossProductTermCount = 180;
 
@@ -76,12 +51,9 @@ namespace BitFunnel
     QueryPlanner::QueryPlanner(TermMatchNode const & tree,
                                unsigned targetRowCount,
                                ISimpleIndex const & index,
-                               QueryResources & resources,
+                               IAllocator & matchTreeAllocator,
                                IDiagnosticStream & diagnosticStream,
-                               QueryInstrumentation & instrumentation,
-                               ResultsBuffer & resultsBuffer,
-                               bool useNativeCode)
-      : m_resultsBuffer(resultsBuffer)
+                               QueryInstrumentation & instrumentation)
     {
         if (diagnosticStream.IsEnabled("planning/term"))
         {
@@ -98,8 +70,7 @@ namespace BitFunnel
         RowPlan const & rowPlan =
             TermPlanConverter::BuildRowPlan(tree,
                                             index,
-                                            // generateNonBodyPlan,
-                                            resources.GetMatchTreeAllocator());
+                                            matchTreeAllocator);
 
         if (diagnosticStream.IsEnabled("planning/row"))
         {
@@ -143,7 +114,7 @@ namespace BitFunnel
             MatchTreeRewriter::Rewrite(rowPlan.GetMatchTree(),
                                        targetRowCount,
                                        c_targetCrossProductTermCount,
-                                       resources.GetMatchTreeAllocator());
+                                       matchTreeAllocator);
 
 
         if (diagnosticStream.IsEnabled("planning/rewrite"))
@@ -159,10 +130,10 @@ namespace BitFunnel
         }
 
         // Compile the match tree into CompileNodes.
-        RankDownCompiler compiler(resources.GetMatchTreeAllocator());
+        RankDownCompiler compiler(matchTreeAllocator);
         compiler.Compile(rewritten);
-        const Rank initialRank = compiler.GetMaximumRank();
-        CompileNode const & compileTree = compiler.CreateTree(initialRank);
+        m_initialRank = compiler.GetMaximumRank();
+        m_compileTree = &compiler.CreateTree(m_initialRank);
 
         if (diagnosticStream.IsEnabled("planning/compile"))
         {
@@ -172,147 +143,42 @@ namespace BitFunnel
 
             out << "--------------------" << std::endl;
             out << "Compile Nodes:" << std::endl;
-            compileTree.Format(*formatter);
+            m_compileTree->Format(*formatter);
             out << std::endl;
         }
 
-        RowSet rowSet(index, *m_planRows, resources.GetMatchTreeAllocator());
-        rowSet.LoadRows();
+        m_rowSet = std::unique_ptr<RowSet>(new RowSet(index, *m_planRows, matchTreeAllocator));
+        m_rowSet->LoadRows();
 
         if (diagnosticStream.IsEnabled("planning/rowset"))
         {
             std::ostream& out = diagnosticStream.GetStream();
             out << "--------------------" << std::endl;
             out << "Row Set:" << std::endl;
-            out << "  ShardCount: " << rowSet.GetShardCount() << std::endl;
-            out << "  Row Count: " << rowSet.GetRowCount() << std::endl;
+            out << "  ShardCount: " << m_rowSet->GetShardCount() << std::endl;
+            out << "  Row Count: " << m_rowSet->GetRowCount() << std::endl;
 
         }
 
-        instrumentation.SetRowCount(rowSet.GetRowCount());
+        instrumentation.SetRowCount(m_rowSet->GetRowCount());
 
-        if (useNativeCode)
-        {
-            RunNativeCode(index,
-                          resources,
-                          instrumentation,
-                          compileTree,
-                          initialRank,
-                          rowSet);
-        }
-        else
-        {
-            RunByteCodeInterpreter(index,
-                                   resources,
-                                   instrumentation,
-                                   compileTree,
-                                   initialRank,
-                                   rowSet);
-        }
     }
 
 
-    void QueryPlanner::RunByteCodeInterpreter(ISimpleIndex const & index,
-                                              QueryResources & resources,
-                                              QueryInstrumentation & instrumentation,
-                                              CompileNode const & compileTree,
-                                              Rank initialRank,
-                                              RowSet const & rowSet)
+    CompileNode const & QueryPlanner::GetCompileTree() const
     {
-        // TODO: Clear results buffer here?
-        compileTree.Compile(m_code);
-        m_code.Seal();
-
-        instrumentation.FinishPlanning();
-        m_resultsBuffer.Reset();
-
-        // Get token before we GetSliceBuffers.
-        {
-            auto token = index.GetIngestor().GetTokenManager().RequestToken();
-
-            for (ShardId shardId = 0; shardId < index.GetIngestor().GetShardCount(); ++shardId)
-            {
-                auto & shard = index.GetIngestor().GetShard(shardId);
-                auto & sliceBuffers = shard.GetSliceBuffers();
-
-                // Iterations per slice calculation.
-                auto iterationsPerSlice = shard.GetSliceCapacity() >> 6 >> initialRank;
-
-                ByteCodeInterpreter intepreter(m_code,
-                                               m_resultsBuffer,
-                                               sliceBuffers.size(),
-                                               sliceBuffers.data(),
-                                               iterationsPerSlice,
-                                               initialRank,
-                                               rowSet.GetRowOffsets(shardId),
-                                               nullptr,
-                                               instrumentation,
-                                               resources.GetCountCacheLines()? shard.GetSliceBufferSize() : 0);
-
-                intepreter.Run();
-            }
-
-            instrumentation.FinishMatching();
-            instrumentation.SetMatchCount(m_resultsBuffer.size());
-        } // End of token lifetime.
+        return *m_compileTree;
     }
 
-
-    void QueryPlanner::RunNativeCode(ISimpleIndex const & index,
-                                     QueryResources & resources,
-                                     QueryInstrumentation & instrumentation,
-                                     CompileNode const & compileTree,
-                                     Rank initialRank,
-                                     RowSet const & rowSet)
+    Rank QueryPlanner::GetInitialRank() const
     {
-         // Perform register allocation on the compile tree.
-         RegisterAllocator const registers(compileTree,
-                                           rowSet.GetRowCount(),
-                                           c_registerBase,
-                                           c_registerCount,
-                                           resources.GetMatchTreeAllocator());
-
-         MatchTreeCompiler compiler(resources,
-                                    compileTree,
-                                    registers,
-                                    initialRank);
-
-
-         // TODO: Clear results buffer here?
-        compileTree.Compile(m_code);
-        m_code.Seal();
-
-        instrumentation.FinishPlanning();
-
-        m_resultsBuffer.Reset();
-
-        // Get token before we GetSliceBuffers.
-        {
-            auto token = index.GetIngestor().GetTokenManager().RequestToken();
-
-            for (ShardId shardId = 0; shardId < index.GetIngestor().GetShardCount(); ++shardId)
-            {
-                auto & shard = index.GetIngestor().GetShard(shardId);
-                auto & sliceBuffers = shard.GetSliceBuffers();
-
-                // Iterations per slice calculation.
-                auto iterationsPerSlice = shard.GetSliceCapacity() >> 6 >> initialRank;
-
-
-                size_t quadwordCount = compiler.Run(sliceBuffers.size(),
-                                                    sliceBuffers.data(),
-                                                    iterationsPerSlice,
-                                                    rowSet.GetRowOffsets(shardId),
-                                                    m_resultsBuffer);
-
-                instrumentation.IncrementQuadwordCount(quadwordCount);
-            }
-
-            instrumentation.FinishMatching();
-            instrumentation.SetMatchCount(m_resultsBuffer.size());
-        } // End of token lifetime.
+        return m_initialRank;
     }
 
+    RowSet const & QueryPlanner::GetRowSet() const
+    {
+        return *m_rowSet;
+    }
 
     IPlanRows const & QueryPlanner::GetPlanRows() const
     {

--- a/src/Plan/src/QueryPlanner.h
+++ b/src/Plan/src/QueryPlanner.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "BitFunnel/NonCopyable.h"        // Inherits from NonCopyable.
-#include "ByteCodeInterpreter.h"
+#include "RowSet.h"
 
 
 namespace BitFunnel
@@ -32,8 +32,6 @@ namespace BitFunnel
     class ISimpleIndex;
     class IThreadResources;
     class QueryInstrumentation;
-    class QueryResources;
-    class ResultsBuffer;
     class RowSet;
     class TermMatchNode;
 
@@ -44,46 +42,26 @@ namespace BitFunnel
         QueryPlanner(TermMatchNode const & tree,
                      unsigned targetRowCount,
                      ISimpleIndex const & index,
-                     // IThreadResources& threadResources,
-                     QueryResources & resources,
+                     IAllocator & matchTreeAllocator,
                      IDiagnosticStream& diagnosticStream,
-                     QueryInstrumentation & instrumentation,
-                     ResultsBuffer & resultsBuffer,
-                     bool useNativeCode);
+                     QueryInstrumentation & instrumentation);
+
+        CompileNode const & GetCompileTree() const;
+
+        Rank GetInitialRank() const;
+
+        RowSet const & GetRowSet() const;
 
         IPlanRows const & GetPlanRows() const;
 
     private:
-        void RunByteCodeInterpreter(ISimpleIndex const & index,
-                                    QueryResources & resources,
-                                    QueryInstrumentation & instrumentation,
-                                    CompileNode const & compileTree,
-                                    Rank maxRank,
-                                    RowSet const & rowSet);
+        CompileNode const * m_compileTree;
 
-        void RunNativeCode(ISimpleIndex const & index,
-                           QueryResources & resources,
-                           QueryInstrumentation & instrumentation,
-                           CompileNode const & compileTree,
-                           Rank maxRank,
-                           RowSet const & rowSet);
+        Rank m_initialRank;
 
+        std::unique_ptr<RowSet> m_rowSet;
+        
         IPlanRows const * m_planRows;
 
-        // The maximum number of iterations that can be performed before a termination
-        // check is mandatory. Details can be found in the MatchTreeCodeGenerator.
-        // const unsigned m_maxIterationsScannedBetweenTerminationChecks;
-
-        // First available row pointer register is R8.
-        // TODO: is this valid on all platforms or only on Windows?
-        static const unsigned c_registerBase = 8;
-
-        // Row pointers stored in the eight registers R8..R15.
-        // TODO: is this valid on all platforms or only on Windows?
-        static const unsigned c_registerCount = 8;
-
-        ByteCodeGenerator m_code;
-
-        ResultsBuffer& m_resultsBuffer;
     };
 }

--- a/src/Plan/src/QueryResources.cpp
+++ b/src/Plan/src/QueryResources.cpp
@@ -34,17 +34,17 @@ namespace BitFunnel
                                    size_t codeAllocatorBytes)
       : m_matchTreeAllocator(new BitFunnel::Allocator(treeAllocatorBytes)),
         m_expressionTreeAllocator(new NativeJIT::Allocator(treeAllocatorBytes)),
-        m_codeAllocator(new NativeJIT::ExecutionBuffer(codeAllocatorBytes))
+        m_codeAllocator(new NativeJIT::ExecutionBuffer(codeAllocatorBytes)),
+        m_countCacheLines(false)
     {
         m_code.reset(new NativeJIT::FunctionBuffer(*m_codeAllocator,
                                                    static_cast<unsigned>(codeAllocatorBytes)));
     }
 
 
-    void QueryResources::EnableCacheLineCounting(ISimpleIndex const & index)
+    void QueryResources::EnableCacheLineCounting()
     {
-        m_cacheLineRecorder.reset(
-            new CacheLineRecorder(index.GetIngestor().GetShard(0).GetSliceBufferSize()));
+        m_countCacheLines = true;
     }
 
 
@@ -54,9 +54,5 @@ namespace BitFunnel
         m_expressionTreeAllocator->Reset();
         // WARNING: Do not reset m_codeAllocator. It is used to provision m_code.
         m_code->Reset();
-        if (m_cacheLineRecorder != nullptr)
-        {
-            m_cacheLineRecorder->Reset();
-        }
     }
 }

--- a/src/Plan/src/QueryResources.h
+++ b/src/Plan/src/QueryResources.h
@@ -25,7 +25,6 @@
 #include <memory>                               // std::unique_ptr embedded.
 
 #include "BitFunnel/Allocators/IAllocator.h"    // Template parameter.
-#include "CacheLineRecorder.h"                  // Template parameter.
 #include "NativeJIT/CodeGen/ExecutionBuffer.h"  // Template parameter.
 #include "NativeJIT/CodeGen/FunctionBuffer.h"   // Template parameter.
 #include "Temporary/Allocator.h"                // Template parameter.
@@ -41,7 +40,7 @@ namespace BitFunnel
         QueryResources(size_t treeAllocatorBytes = 1ull << 16,
                        size_t codeAllocatorBytes = 1ull << 16);
 
-        void EnableCacheLineCounting(ISimpleIndex const & index);
+        void EnableCacheLineCounting();
 
         virtual void Reset();
 
@@ -65,9 +64,9 @@ namespace BitFunnel
             return *m_code;
         }
 
-        CacheLineRecorder* GetCacheLineRecorder() const
+        bool GetCountCacheLines()
         {
-            return m_cacheLineRecorder.get();
+            return m_countCacheLines;
         }
 
     private:
@@ -75,6 +74,6 @@ namespace BitFunnel
         std::unique_ptr<NativeJIT::Allocator> m_expressionTreeAllocator;
         std::unique_ptr<NativeJIT::ExecutionBuffer> m_codeAllocator;
         std::unique_ptr<NativeJIT::FunctionBuffer> m_code;
-        std::unique_ptr<CacheLineRecorder> m_cacheLineRecorder;
+        bool m_countCacheLines;
     };
 }

--- a/src/Plan/src/QueryRunner.cpp
+++ b/src/Plan/src/QueryRunner.cpp
@@ -30,13 +30,15 @@
 #include "BitFunnel/Index/ISimpleIndex.h"
 #include "BitFunnel/Plan/Factories.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
+#include "BitFunnel/Plan/IQueryEngine.h"
 #include "BitFunnel/Plan/QueryParser.h"
 #include "BitFunnel/Plan/QueryRunner.h"
 #include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "BitFunnel/Utilities/Allocator.h"
+#include "ByteCodeQueryEngine.h"
 #include "CsvTsv/Csv.h"
-#include "QueryResources.h"
+#include "NativeJITQueryEngine.h"
 
 
 namespace BitFunnel
@@ -180,18 +182,16 @@ namespace BitFunnel
         //
         // constructor parameters
         //
-        ISimpleIndex const & m_index;
         IStreamConfiguration const & m_config;
         std::vector<std::string> const & m_queries;
         std::vector<QueryInstrumentation::Data> & m_results;
-        bool m_useNativeCode;
         ThreadSynchronizer& m_synchronizer;
 
         std::vector<ResultsBuffer::Result> m_matches;
 
         ResultsBuffer m_resultsBuffer;
 
-        QueryResources m_resources;
+        std::unique_ptr<IQueryEngine> m_queryEngine;
 
         size_t m_queriesProcessed;
 
@@ -212,20 +212,26 @@ namespace BitFunnel
                                    bool useNativeCode,
                                    bool countCacheLines,
                                    ThreadSynchronizer& synchronizer)
-      : m_index(index),
-        m_config(config),
+      : m_config(config),
         m_queries(queries),
         m_results(results),
-        m_useNativeCode(useNativeCode),
         m_synchronizer(synchronizer),
         m_matches(maxResultCount, {nullptr, 0}),
         m_resultsBuffer(index.GetIngestor().GetDocumentCount()),
-        m_resources(c_allocatorSize, c_allocatorSize),
         m_queriesProcessed(0)
     {
+        if (useNativeCode)
+        {
+            m_queryEngine = std::unique_ptr<IQueryEngine>(new NativeJITQueryEngine(index, config, c_allocatorSize, c_allocatorSize));
+        }
+        else
+        {
+            m_queryEngine = std::unique_ptr<IQueryEngine>(new ByteCodeQueryEngine(index, config, c_allocatorSize));
+        }
+
         if (countCacheLines)
         {
-            m_resources.EnableCacheLineCounting();
+            m_queryEngine->EnableDiagnostic("planning/countcachelines");
         }
     }
 
@@ -240,32 +246,20 @@ namespace BitFunnel
         ++m_queriesProcessed;
 
         QueryInstrumentation instrumentation;
-        m_resources.Reset();
 
         size_t queryId = taskId % m_queries.size();
 
         // Parse and run the query, catching ParseError or other RecoverableError
         try
         {
-            QueryParser parser(m_queries[queryId].c_str(),
-                m_config,
-                m_resources.GetMatchTreeAllocator());
-            auto tree = parser.Parse();
+            auto tree = m_queryEngine->Parse(m_queries[queryId].c_str());
             instrumentation.FinishParsing();
 
-            // TODO: remove diagnosticStream and replace with nullable.
-            auto diagnosticStream = Factories::CreateDiagnosticStream(std::cout);
             if (tree != nullptr)
             {
-                Factories::RunQueryPlanner(*tree,
-                                           m_index,
-                                           m_resources,
-                                           *diagnosticStream,
-                                           instrumentation,
-                                           m_resultsBuffer,
-                                           m_useNativeCode);
-
-                instrumentation.QuerySuceeded();
+                m_queryEngine->Run(tree,
+                                   instrumentation,
+                                   m_resultsBuffer);
             }
         }
         catch (RecoverableError e)

--- a/src/Plan/src/QueryRunner.cpp
+++ b/src/Plan/src/QueryRunner.cpp
@@ -225,7 +225,7 @@ namespace BitFunnel
     {
         if (countCacheLines)
         {
-            m_resources.EnableCacheLineCounting(index);
+            m_resources.EnableCacheLineCounting();
         }
     }
 

--- a/src/Plan/src/QueryRunner.cpp
+++ b/src/Plan/src/QueryRunner.cpp
@@ -32,11 +32,11 @@
 #include "BitFunnel/Plan/QueryInstrumentation.h"
 #include "BitFunnel/Plan/QueryParser.h"
 #include "BitFunnel/Plan/QueryRunner.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "BitFunnel/Utilities/Allocator.h"
 #include "CsvTsv/Csv.h"
 #include "QueryResources.h"
-#include "ResultsBuffer.h"
 
 
 namespace BitFunnel

--- a/src/Plan/src/VerifyOneQuery.cpp
+++ b/src/Plan/src/VerifyOneQuery.cpp
@@ -30,13 +30,15 @@
 #include "BitFunnel/Index/IIngestor.h"
 #include "BitFunnel/Index/ISimpleIndex.h"
 #include "BitFunnel/Plan/Factories.h"
+#include "BitFunnel/Plan/IQueryEngine.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
 #include "BitFunnel/Plan/QueryParser.h"     // TODO: Can this move to src/plan?
 #include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Plan/VerifyOneQuery.h"
 #include "BitFunnel/Utilities/Factories.h"
+#include "ByteCodeQueryEngine.h"
 #include "MatchVerifier.h"
-#include "QueryResources.h"
+#include "NativeJITQueryEngine.h"
 #include "TermMatchTreeEvaluator.h"
 
 
@@ -47,14 +49,20 @@ namespace BitFunnel
         std::string query,
         bool compilerMode)
     {
-        QueryResources resources;
-        auto & allocator = resources.GetMatchTreeAllocator();
-
         // TODO: Get this from ISimpleIndex?
-        auto streamConfiguration = Factories::CreateStreamConfiguration();
+        auto streamConfig = Factories::CreateStreamConfiguration();
+        std::unique_ptr<IQueryEngine> queryEngine;
+        const size_t c_allocatorSize = 1ull << 17;
+        if (compilerMode)
+        {
+            queryEngine = std::unique_ptr<IQueryEngine>(new NativeJITQueryEngine(index, *streamConfig, c_allocatorSize, c_allocatorSize));
+        }
+        else
+        {
+            queryEngine = std::unique_ptr<IQueryEngine>(new ByteCodeQueryEngine(index, *streamConfig, c_allocatorSize));
+        }
 
-        QueryParser parser(query.c_str(), *streamConfiguration, allocator);
-        auto tree = parser.Parse();
+        auto tree = queryEngine->Parse(query.c_str());
 
         // TODO: Can MatchVerifier take a char const *? Does it need a copy?
         std::unique_ptr<IMatchVerifier> verifier(new MatchVerifier(query));
@@ -100,13 +108,9 @@ namespace BitFunnel
 
             ResultsBuffer results(index.GetIngestor().GetDocumentCount());
 
-            Factories::RunQueryPlanner(*tree,
-                                       index,
-                                       resources,
-                                       *diagnosticStream,
-                                       instrumentation,
-                                       results,
-                                       compilerMode);
+            queryEngine->Run(tree,
+                             instrumentation,
+                             results);
 
             for (auto result : results)
             {

--- a/src/Plan/src/VerifyOneQuery.cpp
+++ b/src/Plan/src/VerifyOneQuery.cpp
@@ -32,11 +32,11 @@
 #include "BitFunnel/Plan/Factories.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
 #include "BitFunnel/Plan/QueryParser.h"     // TODO: Can this move to src/plan?
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Plan/VerifyOneQuery.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "MatchVerifier.h"
 #include "QueryResources.h"
-#include "ResultsBuffer.h"
 #include "TermMatchTreeEvaluator.h"
 
 

--- a/src/Plan/src/VerifyOneQuerySynthetic.cpp
+++ b/src/Plan/src/VerifyOneQuerySynthetic.cpp
@@ -34,12 +34,12 @@
 #include "BitFunnel/Plan/Factories.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
 #include "BitFunnel/Plan/QueryParser.h"     // TODO: Can this move to src/plan?
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Plan/VerifyOneQuerySynthetic.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "BitFunnel/Utilities/Primes.h"
 #include "MatchVerifier.h"
 #include "QueryResources.h"
-#include "ResultsBuffer.h"
 
 
 namespace BitFunnel

--- a/src/Plan/src/VerifyOneQuerySynthetic.cpp
+++ b/src/Plan/src/VerifyOneQuerySynthetic.cpp
@@ -32,14 +32,16 @@
 #include "BitFunnel/Index/IIngestor.h"
 #include "BitFunnel/Index/ISimpleIndex.h"
 #include "BitFunnel/Plan/Factories.h"
+#include "BitFunnel/Plan/IQueryEngine.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
 #include "BitFunnel/Plan/QueryParser.h"     // TODO: Can this move to src/plan?
 #include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Plan/VerifyOneQuerySynthetic.h"
 #include "BitFunnel/Utilities/Factories.h"
 #include "BitFunnel/Utilities/Primes.h"
+#include "ByteCodeQueryEngine.h"
 #include "MatchVerifier.h"
-#include "QueryResources.h"
+#include "NativeJITQueryEngine.h"
 
 
 namespace BitFunnel
@@ -129,19 +131,26 @@ namespace BitFunnel
         size_t primeFactor,
         bool compilerMode)
     {
-        QueryResources resources;
-        auto & allocator = resources.GetMatchTreeAllocator();
-
         // TODO: Get this from ISimpleIndex?
-        auto streamConfiguration = Factories::CreateStreamConfiguration();
+        auto streamConfig = Factories::CreateStreamConfiguration();
+        std::unique_ptr<IQueryEngine> queryEngine;
+        const size_t c_allocatorSize = 1ull << 17;
+        if (compilerMode)
+        {
+            queryEngine = std::unique_ptr<IQueryEngine>(new NativeJITQueryEngine(index, *streamConfig, c_allocatorSize, c_allocatorSize));
+        }
+        else
+        {
+            queryEngine = std::unique_ptr<IQueryEngine>(new ByteCodeQueryEngine(index, *streamConfig, c_allocatorSize));
+        }
+
 
         std::stringstream queryStream;
         queryStream << "p";
         queryStream << primeFactor;
         std::string query(queryStream.str());
 
-        QueryParser parser(query.c_str(), *streamConfiguration, allocator);
-        auto tree = parser.Parse();
+        auto tree = queryEngine->Parse(query.c_str());
 
         // TODO: Can MatchVerifier take a char const *? Does it need a copy?
         std::unique_ptr<IMatchVerifier> verifier(new MatchVerifier(query));
@@ -177,13 +186,7 @@ namespace BitFunnel
 
             ResultsBuffer results(index.GetIngestor().GetDocumentCount());
 
-            Factories::RunQueryPlanner(*tree,
-                                       index,
-                                       resources,
-                                       *diagnosticStream,
-                                       instrumentation,
-                                       results,
-                                       compilerMode);
+            queryEngine->Run(tree, instrumentation, results);
 
             for (auto result : results)
             {

--- a/src/Plan/test/ByteCodeVerifier.cpp
+++ b/src/Plan/test/ByteCodeVerifier.cpp
@@ -30,12 +30,12 @@
 #include "BitFunnel/Index/ISimpleIndex.h"
 #include "BitFunnel/Index/RowIdSequence.h"
 #include "BitFunnel/Plan/QueryInstrumentation.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Utilities/Allocator.h"
 #include "BitFunnel/Utilities/Factories.h"  // TODO: only for diagnosticStream. Remove.
 #include "ByteCodeInterpreter.h"
 #include "ByteCodeVerifier.h"
 #include "CompileNode.h"
-#include "ResultsBuffer.h"
 #include "TextObjectParser.h"
 
 

--- a/src/Plan/test/ByteCodeVerifier.cpp
+++ b/src/Plan/test/ByteCodeVerifier.cpp
@@ -77,7 +77,7 @@ namespace BitFunnel
             m_rowOffsets.data(),
             nullptr,
             instrumentation,
-            nullptr);
+            0);
 
         interpreter.Run();
 

--- a/src/Plan/test/CodeVerifierBase.cpp
+++ b/src/Plan/test/CodeVerifierBase.cpp
@@ -34,10 +34,10 @@
 #include "BitFunnel/Index/IShard.h"
 #include "BitFunnel/Index/ISimpleIndex.h"
 #include "BitFunnel/Index/RowIdSequence.h"
+#include "BitFunnel/Plan/ResultsBuffer.h"
 #include "BitFunnel/Utilities/Factories.h"  // TODO: only for diagnosticStream. Remove.
 #include "ByteCodeInterpreter.h"
 #include "CodeVerifierBase.h"
-#include "ResultsBuffer.h"
 
 
 namespace BitFunnel


### PR DESCRIPTION
These commits:

* Move ResultsBuffer.h from /src/Plan/src/ to inc/BitFunnel/Plan.
* Replace the non-public QueryResources with two QueryEngines, which provide a context for performing parse, plan and execution of queries. One engine uses NativeJIT and the other is the ByteCode interpreter. The NativeJIT query engine is publicly accessible via a Factory function.

With these changes, an external program can use BitFunnel as a library for running queries and retrieving the results, without having to make use of internal-only include files.