### PR TITLE
Add 'query docs' option

### DIFF
--- a/tools/BitFunnel/src/QueryCommand.h
+++ b/tools/BitFunnel/src/QueryCommand.h
@@ -40,7 +40,12 @@ namespace BitFunnel
         static ICommand::Documentation GetDocumentation();
 
     private:
-        bool m_isSingleQuery;
+        enum QueryCommand {
+            QueryOne,
+            QueryLog,
+            QueryDocs
+        };
+        QueryCommand m_queryCommand;
         std::string m_query;
     };
 }


### PR DESCRIPTION
This adds a new 'doc' option to the BitFunnel tool's query command. Similar to 'query one', it performs a single query and returns the number of results. In addition, it lists the ids for all matching documents.